### PR TITLE
회원가입시 위치인증 파라미터값 없는경우 서버오류 발생 : feat : MemberLocation 지번주소, 도로명주소 필드 삭제 https://github.com/TEAM-ROMROM/RomRom-BE/issues/101

### DIFF
--- a/src/main/java/com/romrom/romback/domain/object/postgres/MemberLocation.java
+++ b/src/main/java/com/romrom/romback/domain/object/postgres/MemberLocation.java
@@ -51,10 +51,4 @@ public class MemberLocation {
 
   // 리
   private String ri;
-
-  // 지번 주소
-  private String fullAddress;
-
-  // 도로명 주소
-  private String roadAddress;
 }


### PR DESCRIPTION
회원가입시 위치인증 파라미터값 없는경우 서버오류 발생 : feat : MemberLocation 지번주소, 도로명주소 필드 삭제 https://github.com/TEAM-ROMROM/RomRom-BE/issues/101