### PR TITLE
20250407 #90 기능개선 로그인 소셜 로그인 시 클라이언트로부터 넘어오는 nickname값 제거 후 랜덤 닉네임 지정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,9 @@ dependencies {
 
     // SMB
     implementation 'org.springframework.integration:spring-integration-smb:6.4.2'
+
+    // DataFaker
+    implementation 'net.datafaker:datafaker:2.4.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ configurations {
 
 repositories {
     mavenCentral()
+    // Suh-Nexus 추가
+    maven {
+        url "http://suh-project.synology.me:9999/repository/maven-releases/"
+        allowInsecureProtocol = true
+    }
 }
 
 dependencies {
@@ -88,8 +93,11 @@ dependencies {
     // SMB
     implementation 'org.springframework.integration:spring-integration-smb:6.4.2'
 
-    // DataFaker
-    implementation 'net.datafaker:datafaker:2.4.2'
+    // Suh-Random-Engine
+    implementation 'me.suhsaechan:suh-random-engine:1.0.1'
+
+    // Suh-Logger
+    implementation 'me.suhsaechan:suh-logger:1.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/romrom/romback/domain/controller/AuthControllerDocs.java
+++ b/src/main/java/com/romrom/romback/domain/controller/AuthControllerDocs.java
@@ -13,6 +13,12 @@ public interface AuthControllerDocs {
 
   @ApiChangeLogs({
       @ApiChangeLog(
+          date = "2025.04.07",
+          author = Author.WISEUNGJAE,
+          issueNumber = 90,
+          description = "소셜 로그인 시 nickname 제거 후 랜덤 닉네임 지정"
+      ),
+      @ApiChangeLog(
           date = "2025.02.23",
           author = Author.SUHSAECHAN,
           issueNumber = 32,

--- a/src/main/java/com/romrom/romback/domain/service/AuthService.java
+++ b/src/main/java/com/romrom/romback/domain/service/AuthService.java
@@ -14,9 +14,11 @@ import com.romrom.romback.global.exception.CustomException;
 import com.romrom.romback.global.exception.ErrorCode;
 import com.romrom.romback.global.jwt.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.datafaker.Faker;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
   private static final String REFRESH_KEY_PREFIX = "RT:";
+  private final Faker nicknameFaker = new Faker(new Locale("ko","KR"));
 
   private final MemberRepository memberRepository;
   private final JwtUtil jwtUtil;
@@ -42,11 +45,10 @@ public class AuthService {
 
     // 요청 값으로부터 사용자 정보 획득
     String email = request.getEmail();
-    String nickname = request.getNickname();
+    // 랜덤 닉네임으로 로직 변경
+    String nickname = nicknameFaker.name().fullName();
     String profileUrl = request.getProfileUrl();
     SocialPlatform socialPlatform = request.getSocialPlatform();
-
-    boolean isFirstLogin = false;
 
     // 회원이 없을 시 신규 가입 처리
     Member member = memberRepository.findByEmail(email)

--- a/src/main/java/com/romrom/romback/domain/service/AuthService.java
+++ b/src/main/java/com/romrom/romback/domain/service/AuthService.java
@@ -14,11 +14,10 @@ import com.romrom.romback.global.exception.CustomException;
 import com.romrom.romback.global.exception.ErrorCode;
 import com.romrom.romback.global.jwt.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.datafaker.Faker;
+import me.suhsaechan.suhnicknamegenerator.core.SuhRandomKit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
   private static final String REFRESH_KEY_PREFIX = "RT:";
-  private final Faker nicknameFaker = new Faker(new Locale("ko","KR"));
+  private final SuhRandomKit suhRandomKit = SuhRandomKit.builder().locale("ko").uuidLength(4).numberLength(4).build();
 
   private final MemberRepository memberRepository;
   private final JwtUtil jwtUtil;
@@ -42,11 +41,8 @@ public class AuthService {
    * @param request socialPlatform, email, nickname, profileUrl
    */
   public AuthResponse signIn(AuthRequest request) {
-
-    // 요청 값으로부터 사용자 정보 획득
     String email = request.getEmail();
-    // 랜덤 닉네임으로 로직 변경
-    String nickname = nicknameFaker.name().fullName();
+    String nickname = suhRandomKit.nicknameWithNumber(); // 랜덤 닉네임 생성 : 2025.04.21 : #121
     String profileUrl = request.getProfileUrl();
     SocialPlatform socialPlatform = request.getSocialPlatform();
 

--- a/src/main/java/com/romrom/romback/domain/service/TestService.java
+++ b/src/main/java/com/romrom/romback/domain/service/TestService.java
@@ -13,6 +13,7 @@ import com.romrom.romback.domain.repository.postgres.MemberRepository;
 import com.romrom.romback.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.suhsaechan.suhnicknamegenerator.core.SuhRandomKit;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class TestService {
 
   private final MemberRepository memberRepository;
   private final JwtUtil jwtUtil;
+  private final SuhRandomKit suhRandomKit = SuhRandomKit.builder().locale("ko").uuidLength(4).numberLength(4).build();
 
   /**
    * 회원 이메일로 가짜 로그인 처리
@@ -40,6 +42,7 @@ public class TestService {
           Member newMember = Member.builder()
               .email(email)
               .socialPlatform(request.getSocialPlatform())
+              .nickname(suhRandomKit.nicknameWithNumber())
               .profileUrl("TEST")
               .role(Role.ROLE_USER)
               .accountStatus(AccountStatus.ACTIVE_ACCOUNT)

--- a/src/test/java/com/romrom/romback/domain/service/TestServiceTest.java
+++ b/src/test/java/com/romrom/romback/domain/service/TestServiceTest.java
@@ -1,0 +1,36 @@
+package com.romrom.romback.domain.service;
+
+import static me.suhsaechan.suhlogger.util.SuhLogger.lineLog;
+import static me.suhsaechan.suhlogger.util.SuhLogger.superLog;
+import static me.suhsaechan.suhlogger.util.SuhLogger.timeLog;
+
+import lombok.extern.slf4j.Slf4j;
+import me.suhsaechan.suhnicknamegenerator.core.SuhRandomKit;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@Slf4j
+class TestServiceTest {
+
+  @Test
+  public void mainTest() {
+    lineLog("테스트시작");
+
+    lineLog(null);
+    timeLog(this::randomNickname_테스트);
+    lineLog(null);
+
+    lineLog("테스트종료");
+  }
+
+  public void randomNickname_테스트(){
+   SuhRandomKit suhRandomKit = SuhRandomKit.builder().locale("ko").uuidLength(4).numberLength(4).build();
+
+    String nicknameWithNumber = suhRandomKit.nicknameWithNumber();
+    superLog(nicknameWithNumber);
+
+  }
+}

--- a/src/test/java/com/romrom/romback/global/util/LogUtilTest.java
+++ b/src/test/java/com/romrom/romback/global/util/LogUtilTest.java
@@ -4,6 +4,7 @@ import static com.romrom.romback.global.util.LogUtil.lineLog;
 import static com.romrom.romback.global.util.LogUtil.timeLog;
 
 import lombok.extern.slf4j.Slf4j;
+import me.suhsaechan.suhlogger.util.SuhLogger;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -15,13 +16,25 @@ class LogUtilTest {
 
   @Test
   public void mainTest() {
-    lineLog("updateIsDownloadedDocumentFiles_동기적");
-    timeLog(this::디버그로그_테스트);
+    lineLog("테스트시작");
+//    lineLog("updateIsDownloadedDocumentFiles_동기적");
+//    timeLog(this::디버그로그_테스트);
+    timeLog(this::suh_logger_테스트);
     lineLog(null);
+    lineLog("테스트종료");
   }
 
   public void 디버그로그_테스트(){
     LogUtil.lineLogDebug("테스트 라인 로그");
     LogUtil.superLogDebug("테스트 객체");
+  }
+
+  public void suh_logger_테스트(){
+    SuhLogger.lineLog(null);
+    SuhLogger.lineLog("테스트 라인 로그");
+    SuhLogger.lineLog("성공메시지");
+    SuhLogger.lineLog(null);
+
+    SuhLogger.timeLog(this::디버그로그_테스트);
   }
 }


### PR DESCRIPTION
@Cassiiopeia @Chuseok22 @nayoung04  
우선 간단하게 한국 성과 한국 이름으로 (ex : 오서윤) nickname이 정해지더라고요? 
이거 커스터마이징해서 형용사 + 동물로 구현하는게 나을까요? 리뷰 부탁드림둥~!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 소셜 로그인 및 테스트 로그인 시 닉네임이 무작위로 자동 생성되도록 변경되었습니다.

- **버그 수정**
	- 기존 닉네임 생성 라이브러리 대신 새로운 랜덤 엔진 및 로깅 라이브러리가 적용되었습니다.

- **문서화**
	- 소셜 로그인 시 닉네임 파라미터 제거 및 무작위 닉네임 부여에 대한 API 변경 로그가 추가되었습니다.

- **테스트**
	- 닉네임 생성 및 로깅 관련 테스트 코드가 새로운 라이브러리 기반으로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->