### PR TITLE
Test

### DIFF
--- a/src/main/java/com/romrom/romback/domain/controller/TestController.java
+++ b/src/main/java/com/romrom/romback/domain/controller/TestController.java
@@ -8,6 +8,7 @@ import com.romrom.romback.global.aspect.LogMonitoringInvocation;
 import com.romrom.romback.global.docs.ApiChangeLog;
 import com.romrom.romback.global.docs.ApiChangeLogs;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/test")
 public class TestController {
+
   private final TestService testService;
 
   // 테스트 계정 생성을 위한 API 입니다
@@ -70,5 +72,59 @@ public class TestController {
   @LogMonitoringInvocation
   public ResponseEntity<TestResponse> testSignUp(@ModelAttribute TestRequest request) {
     return ResponseEntity.ok(testService.testSignIn(request));
+  }
+
+  @ApiChangeLogs({
+      @ApiChangeLog(
+          date = "2025.05.23",
+          author = Author.KIMNAYOUNG,
+          issueNumber = 122,
+          description = "Mock 사용자 생성"
+      )
+  })
+  @Operation(
+      summary = "Mock 사용자 생성",
+      description = """
+          ## 인증(JWT): **불필요**
+          
+          ## 요청 파라미터 
+          - **`count`**: 생성할 Mock 사용자 수
+          
+          ## 반환값 (없음)
+          
+          """
+  )
+  @PostMapping(value = "/user")
+  @LogMonitoringInvocation
+  public ResponseEntity<Void> createMockMember(@Schema(defaultValue = "20") Integer count) {
+    testService.createMockMembers(count);
+    return ResponseEntity.ok().build();
+  }
+
+  @ApiChangeLogs({
+      @ApiChangeLog(
+          date = "2025.05.23",
+          author = Author.KIMNAYOUNG,
+          issueNumber = 122,
+          description = "Mock 물품 생성"
+      )
+  })
+  @Operation(
+      summary = "Mock 물품 생성",
+      description = """
+          ## 인증(JWT): **불필요**
+          
+          ## 요청 파라미터 
+          - **`count`**: 생성할 Mock 물품 수
+          
+          ## 반환값 (없음)
+          
+          """
+  )
+  @PostMapping(value = "/item")
+  @LogMonitoringInvocation
+  public ResponseEntity<Void> createMockItem(@Schema(defaultValue = "20") Integer count) {
+    testService.createMockItems(count);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/romrom/romback/domain/service/TestService.java
+++ b/src/main/java/com/romrom/romback/domain/service/TestService.java
@@ -4,15 +4,28 @@ import static com.romrom.romback.global.jwt.JwtUtil.REFRESH_KEY_PREFIX;
 import static com.romrom.romback.global.util.LogUtil.lineLog;
 import static com.romrom.romback.global.util.LogUtil.superLogDebug;
 
+import com.github.javafaker.Faker;
 import com.romrom.romback.domain.object.constant.AccountStatus;
+import com.romrom.romback.domain.object.constant.ItemCategory;
+import com.romrom.romback.domain.object.constant.ItemCondition;
+import com.romrom.romback.domain.object.constant.ItemTradeOption;
 import com.romrom.romback.domain.object.constant.Role;
+import com.romrom.romback.domain.object.constant.SocialPlatform;
 import com.romrom.romback.domain.object.dto.CustomUserDetails;
 import com.romrom.romback.domain.object.dto.TestRequest;
 import com.romrom.romback.domain.object.dto.TestResponse;
+import com.romrom.romback.domain.object.postgres.Item;
+import com.romrom.romback.domain.object.postgres.ItemImage;
 import com.romrom.romback.domain.object.postgres.Member;
+import com.romrom.romback.domain.repository.postgres.ItemImageRepository;
+import com.romrom.romback.domain.repository.postgres.ItemRepository;
 import com.romrom.romback.domain.repository.postgres.MemberRepository;
 import com.romrom.romback.global.jwt.JwtUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.suhsaechan.suhnicknamegenerator.core.SuhRandomKit;
@@ -26,13 +39,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class TestService {
 
   private final MemberRepository memberRepository;
+  private final ItemRepository itemRepository;
+  private final ItemImageRepository itemImageRepository;
   private final JwtUtil jwtUtil;
   private final RedisTemplate<String, Object> redisTemplate;
   private final SuhRandomKit suhRandomKit = SuhRandomKit.builder().locale("ko").uuidLength(4).numberLength(4).build();
+  private final Faker koFaker = new Faker(new Locale("ko", "KR"));
+  private final Faker enFaker = new Faker(new Locale("en"));
 
   /**
-   * 회원 이메일로 가짜 로그인 처리
-   * 회원이 없으면 신규 가입 후, isFirstLogin 설정
+   * 회원 이메일로 가짜 로그인 처리 회원이 없으면 신규 가입 후, isFirstLogin 설정
    */
   @Transactional
 
@@ -84,5 +100,96 @@ public class TestService {
         .isFirstLogin(member.getIsFirstLogin())
         .isFirstItemPosted(member.getIsFirstItemPosted())
         .build();
+  }
+
+  // count 만큼 Mock 사용자 생성
+  @Transactional
+  public void createMockMembers(Integer count) {
+    List<Member> mockMembers = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      try {
+        mockMembers.add(createMockMember());
+      } catch (Exception e) {
+        log.error("Mock 사용자 생성 실패: {}", e.getMessage());
+      }
+    }
+    log.debug("Mock 사용자 {}명 생성 완료", mockMembers.size());
+  }
+
+  /**
+   * Mock Member 생성 DataFaker 로 이메일, 닉네임, 프로필 URL, 소셜 플랫폼, 역할, 계정 상태를 생성
+   *
+   * @return 생성된 Member 객체
+   */
+  @Transactional
+  public Member createMockMember() {
+    Member mockMember = Member.builder()
+        .email(enFaker.internet().emailAddress())
+        .nickname(suhRandomKit.nicknameWithNumber())
+        .profileUrl(enFaker.internet().image())
+        .socialPlatform(enFaker.options().option(SocialPlatform.class))
+        .role(Role.ROLE_USER)
+        .accountStatus(AccountStatus.ACTIVE_ACCOUNT)
+        .build();
+
+    // Mock Member 저장
+    memberRepository.save(mockMember);
+    return mockMember;
+  }
+
+  // count 만큼 Mock 물품 생성
+  @Transactional
+  public void createMockItems(Integer count) {
+    List<Item> mockItems = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      try {
+        mockItems.add(createMockItem());
+      } catch (Exception e) {
+        log.error("Mock 물품 생성 실패: {}", e.getMessage());
+      }
+    }
+    log.debug("Mock 물품 {}개 생성 완료", mockItems.size());
+  }
+
+  /**
+   * Mock Item 생성 DataFaker 로 물품명, 물품 설명, 카테고리, 상태, 거래 옵션을 생성
+   *
+   * @return 생성된 Item 객체
+   */
+  @Transactional
+  public Item createMockItem() {
+    Member mockMember = createMockMember();
+
+    List<ItemTradeOption> tradeOptions = Stream.generate(() -> enFaker.options().option(ItemTradeOption.class))
+        .distinct()
+        .limit(enFaker.number().numberBetween(1, 3))
+        .toList();
+
+    Item mockItem = Item.builder()
+        .member(mockMember)
+        .itemName(koFaker.commerce().productName())
+        .itemDescription(koFaker.lorem().sentence())
+        .itemCategory(enFaker.options().option(ItemCategory.class))
+        .itemCondition(enFaker.options().option(ItemCondition.class))
+        .itemTradeOptions(tradeOptions)
+        .likeCount(enFaker.number().numberBetween(0, 100))
+        .price(enFaker.number().numberBetween(10, 1001) * 100)
+        .build();
+
+    // Mock Item 저장
+    itemRepository.save(mockItem);
+
+    ItemImage mockItemImage = ItemImage.builder()
+        .item(mockItem)
+        .imageUrl(enFaker.internet().image())
+        .filePath("/mock/path/" + enFaker.file().fileName())
+        .originalFileName(enFaker.file().fileName())
+        .uploadedFileName("mock_" + enFaker.file().fileName())
+        .fileSize(enFaker.number().numberBetween(10000L, 500000L))
+        .build();
+
+    // Mock ItemImage 저장
+    itemImageRepository.save(mockItemImage);
+    return mockItem;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 테스트용 목 데이터를 생성하는 두 개의 엔드포인트가 추가되었습니다. 이제 별도의 인증 없이 사용자와 아이템 목 데이터를 각각 생성할 수 있습니다.

- **문서화**
    - 새로 추가된 엔드포인트에 대한 상세한 Swagger/OpenAPI 문서가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->