### PR TITLE
SMB 서버 장애로 인한 다른 프로토콜로 파일 업로드 구현 : feat : FTP 프로토콜 이용한 업로드, 삭제 로직 추가 및 적용 변경 사항에 대한 설명 https://github.com/TEAM-ROMROM/RomRom-BE/issues/156

### DIFF
--- a/RomRom-Common/build.gradle
+++ b/RomRom-Common/build.gradle
@@ -44,7 +44,10 @@ dependencies {
     // Utilities - API로 제공
     api "org.reflections:reflections:${reflectionsVersion}"
     api "org.springframework.integration:spring-integration-smb:${springIntegrationSmbVersion}"
-    
+    api "org.springframework.integration:spring-integration-ftp:${springIntegrationFtpVersion}"
+    api 'commons-net:commons-net'
+
+
     // Suh Libraries - API로 제공
     api "me.suhsaechan:suh-random-engine:${suhRandomEngineVersion}"
     api "me.suhsaechan:suh-logger:${suhLoggerVersion}"

--- a/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
@@ -60,9 +60,9 @@ public enum ErrorCode {
 
   INVALID_FILE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 파일이 요청되었습니다."),
 
-  FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SMB 파일 업로드 중 오류가 발생했습니다."),
+  FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FTP 파일 업로드 중 오류가 발생했습니다."),
 
-  FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SMB 파일 삭제 중 오류가 발생했습니다."),
+  FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FTP 파일 삭제 중 오류가 발생했습니다."),
 
   // ITEM
 

--- a/RomRom-Common/src/main/java/com/romrom/common/service/FtpService.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/service/FtpService.java
@@ -1,0 +1,171 @@
+package com.romrom.common.service;
+
+import com.romrom.common.constant.MimeType;
+import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.ErrorCode;
+import com.romrom.common.util.FileUtil;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.romrom.common.util.CommonUtil.nvl;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FtpService {
+
+  private final MessageChannel ftpUploadChannel;
+  private final MessageChannel ftpDeleteChannel;
+  @Qualifier("applicationTaskExecutor")
+  private final TaskExecutor taskExecutor;
+
+  @Value("${ftp.root-dir}")
+  private String rootDir;
+
+  @Value("${ftp.dir}")
+  private String dir;
+
+  private static final int UPLOAD_FILE_MAX_COUNT = 10;
+
+  /**
+   * FTP 파일 업로드 (다중)
+   */
+  @Transactional
+  public CompletableFuture<List<String>> uploadFile(List<MultipartFile> files) {
+    if (files.size() > UPLOAD_FILE_MAX_COUNT || files.isEmpty()) {
+      log.error("파일 개수 오류: 최대 {}, 요청 {}", UPLOAD_FILE_MAX_COUNT, files.size());
+      throw new CustomException(ErrorCode.INVALID_FILE_REQUEST);
+    }
+    int requestFileCount = files.size();
+    List<CompletableFuture<String>> futures = new ArrayList<>();
+
+    for (MultipartFile file : files) {
+      CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+        try {
+          return uploadFile(file);
+        } catch (Exception e) {
+          log.error("멀티스레드 업로드 중 오류: {}", e.getMessage());
+          throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+        }
+      }, taskExecutor);
+      futures.add(future);
+    }
+
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+      .thenApply(result -> {
+        List<String> successfulUploads = new ArrayList<>();
+        boolean failureOccurred = false;
+        for (CompletableFuture<String> future : futures) {
+          try {
+            successfulUploads.add(future.get());
+          } catch (Exception e) {
+            log.error("비동기 업로드 실패: {}", e.getMessage());
+            failureOccurred = true;
+          }
+        }
+        if (failureOccurred || successfulUploads.size() != requestFileCount) {
+          log.error("업로드 실패: 요청={}, 성공={}", requestFileCount, successfulUploads.size());
+          deleteFile(successfulUploads);
+          throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+        }
+        log.debug("FTP 업로드 완료: {}개 성공", successfulUploads.size());
+        return successfulUploads;
+      })
+      .exceptionally(throwable -> {
+        log.error("전체 업로드 오류: {}", throwable.getMessage());
+        throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+      });
+  }
+
+  /**
+   * FTP 파일 업로드 (단일)
+   */
+  @Transactional
+  public String uploadFile(MultipartFile file) {
+    validateFile(file);
+    try {
+      String fileName = FileUtil.generateFilename(file.getOriginalFilename());
+      String filePath = FileUtil.generateFtpFilePath(rootDir, dir, fileName);
+
+      log.debug("FTP 파일 업로드 시작: 파일명={}, 크기={} 바이트", fileName, file.getSize());
+      try (InputStream inputStream = file.getInputStream()) {
+        Message<InputStream> message = MessageBuilder
+          .withPayload(inputStream)
+          .setHeader("file_name", fileName)
+          .build();
+        log.debug("FTP 메시지 생성 완료: {}", message);
+
+        ftpUploadChannel.send(message);
+        log.debug("FTP 파일 업로드 성공: {}", fileName);
+        return filePath;
+      }
+    } catch (Exception e) {
+      log.error("FTP 파일 업로드 실패: {}", file.getOriginalFilename(), e);
+      throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+    }
+  }
+
+  /**
+   * FTP 파일 삭제
+   */
+  public void deleteFile(List<String> fileNames) {
+    log.debug("FTP 파일 삭제 요청: {}개", fileNames.size());
+    if (fileNames.isEmpty()) {
+      log.warn("삭제할 파일 리스트가 비어있습니다.");
+      throw new CustomException(ErrorCode.INVALID_FILE_REQUEST);
+    }
+
+    for (String fileName : fileNames) {
+      try {
+        Message<String> deleteMessage = MessageBuilder
+          .withPayload(fileName)
+          .setHeader("file_name", fileName)
+          .build();
+        ftpDeleteChannel.send(deleteMessage);
+        log.debug("FTP 파일 삭제 성공: {}", fileName);
+      } catch (Exception e) {
+        log.error("FTP 파일 삭제 실패: {}", fileName, e);
+        throw new CustomException(ErrorCode.FILE_DELETE_ERROR);
+      }
+    }
+  }
+
+  /**
+   * 업로드된 파일 유효성 검사
+   */
+  private void validateFile(MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      log.error("요청된 파일이 비어있습니다");
+      throw new CustomException(ErrorCode.INVALID_FILE_REQUEST);
+    }
+
+    String mimeType = file.getContentType();
+    if (nvl(mimeType, "").isEmpty()) {
+      log.error("Mime 타입이 비어있습니다.");
+      throw new CustomException(ErrorCode.INVALID_FILE_REQUEST);
+    }
+    if (!MimeType.isValidMimeType(mimeType)) {
+      log.error("유효하지 않은 Mime 타입입니다.");
+      throw new CustomException(ErrorCode.INVALID_FILE_REQUEST);
+    }
+    if (!MimeType.isValidImageMimeType(mimeType)) {
+      log.error("이미지 파일이 아닙니다");
+      throw new CustomException(ErrorCode.INVALID_FILE_REQUEST);
+    }
+
+    log.debug("파일 검증 성공: {}, MIME={}", file.getOriginalFilename(), mimeType);
+  }
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/util/FileUtil.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/util/FileUtil.java
@@ -24,4 +24,8 @@ public class FileUtil {
   public static String generateSmbFilePath(String... parts) {
     return "/" + String.join("/", parts);
   }
+
+  public static String generateFtpFilePath(String... parts) {
+    return "/" + String.join("/", parts);
+  }
 }

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemImageService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemImageService.java
@@ -1,5 +1,6 @@
 package com.romrom.item.service;
 
+import com.romrom.common.service.FtpService;
 import com.romrom.common.service.SmbService;
 import com.romrom.common.exception.CustomException;
 import com.romrom.common.exception.ErrorCode;
@@ -21,11 +22,12 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 public class ItemImageService {
 
-  @Value("${smb.host}")
+  @Value("${ftp.host}")
   private String baseUrl;
 
   private final ItemImageRepository itemImageRepository;
   private final SmbService smbService;
+  private final FtpService ftpService;
 
   // 물품 사진 저장
   @Transactional
@@ -33,7 +35,7 @@ public class ItemImageService {
     List<ItemImage> itemImages = new ArrayList<>();
     try {
       // SMB 이미지 업로드
-      List<String> uploadedFilePaths = smbService.uploadFile(itemImageFiles).join();
+      List<String> uploadedFilePaths = ftpService.uploadFile(itemImageFiles).join();
       for (int i = 0; i < uploadedFilePaths.size(); i++) {
         String filePath = uploadedFilePaths.get(i);
         MultipartFile file = itemImageFiles.get(i);

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
@@ -51,6 +51,7 @@ public class ItemService {
         .itemCondition(request.getItemCondition())
         .itemTradeOptions(request.getItemTradeOptions())
         .price(request.getItemPrice())
+        .likeCount(0)
         .build();
     itemRepository.save(item);
 

--- a/RomRom-Web/src/main/java/com/romrom/web/config/FtpConfig.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/config/FtpConfig.java
@@ -4,6 +4,7 @@ package com.romrom.web.config;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.net.ftp.FTPClient;
+import org.apache.commons.net.ftp.FTPFile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
+import org.springframework.integration.file.remote.session.CachingSessionFactory;
 import org.springframework.integration.ftp.dsl.Ftp;
 import org.springframework.integration.ftp.inbound.FtpInboundFileSynchronizer;
 import org.springframework.integration.ftp.session.DefaultFtpSessionFactory;
@@ -47,6 +49,17 @@ public class FtpConfig {
     factory.setUsername(username);
     factory.setPassword(password);
     factory.setClientMode(FTPClient.PASSIVE_LOCAL_DATA_CONNECTION_MODE);
+    factory.setConnectTimeout(10000); // 10초
+    factory.setDefaultTimeout(30000); // 30초
+    factory.setDataTimeout(30000); // 30초
+    return factory;
+  }
+
+  @Bean
+  public CachingSessionFactory<FTPFile> cachingFtpSessionFactory() {
+    CachingSessionFactory<FTPFile> factory = new CachingSessionFactory<>(ftpSessionFactory());
+    factory.setPoolSize(10);        // 최대 10개 연결 유지
+    factory.setSessionWaitTimeout(5000); // 연결 대기 시간 5초
     return factory;
   }
 

--- a/RomRom-Web/src/main/java/com/romrom/web/config/FtpConfig.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/config/FtpConfig.java
@@ -1,0 +1,99 @@
+
+package com.romrom.web.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.net.ftp.FTPClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.expression.common.LiteralExpression;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
+import org.springframework.integration.ftp.dsl.Ftp;
+import org.springframework.integration.ftp.inbound.FtpInboundFileSynchronizer;
+import org.springframework.integration.ftp.session.DefaultFtpSessionFactory;
+import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
+import org.springframework.messaging.MessageChannel;
+
+@Configuration
+@RequiredArgsConstructor
+public class FtpConfig {
+
+  @Value("${ftp.host}")
+  private String host;
+
+  @Value("${ftp.port}")
+  private int port;
+
+  @Value("${ftp.username}")
+  private String username;
+
+  @Value("${ftp.password}")
+  private String password;
+
+  @Value("${ftp.root-dir}")
+  private String rootDir;
+
+  @Value("${ftp.dir}")
+  private String dir;
+
+  @Bean
+  public DefaultFtpSessionFactory ftpSessionFactory() {
+    DefaultFtpSessionFactory factory = new DefaultFtpSessionFactory();
+    factory.setHost(host);
+    factory.setPort(port);
+    factory.setUsername(username);
+    factory.setPassword(password);
+    factory.setClientMode(FTPClient.PASSIVE_LOCAL_DATA_CONNECTION_MODE);
+    return factory;
+  }
+
+  @Bean
+  public FtpRemoteFileTemplate ftpRemoteFileTemplate(DefaultFtpSessionFactory ftpSessionFactory) {
+    FtpRemoteFileTemplate template = new FtpRemoteFileTemplate(ftpSessionFactory);
+    template.setRemoteDirectoryExpression(new LiteralExpression("/" + rootDir + "/" + dir));
+    template.setFileNameExpression(new LiteralExpression("headers['file_name']"));
+    return template;
+  }
+
+  // 파일 동기화 설정
+  @Bean
+  public FtpInboundFileSynchronizer ftpInboundFileSynchronizer() {
+    FtpInboundFileSynchronizer synchronizer = new FtpInboundFileSynchronizer(ftpSessionFactory());
+    synchronizer.setDeleteRemoteFiles(false); // 다운로드 후 서버에서 삭제 여부
+    synchronizer.setRemoteDirectory(dir); // "/romrom/images"
+    return synchronizer;
+  }
+
+  @Bean
+  public MessageChannel ftpUploadChannel() {
+    return new DirectChannel();
+  }
+
+  @Bean
+  public MessageChannel ftpDeleteChannel() {
+    return new DirectChannel();
+  }
+
+  @Bean
+  public IntegrationFlow ftpUploadFlow(FtpRemoteFileTemplate ftpRemoteFileTemplate) {
+    return IntegrationFlow.from("ftpUploadChannel")
+      .handle(Ftp.outboundAdapter(ftpRemoteFileTemplate)
+        .remoteDirectory(dir)
+        .autoCreateDirectory(true)
+        .fileNameExpression("headers['file_name']")
+      )
+      .get();
+  }
+
+  @Bean
+  public IntegrationFlow ftpDeleteFlow(FtpRemoteFileTemplate ftpRemoteFileTemplate) {
+    return IntegrationFlow.from("ftpDeleteChannel")
+      .handle(Ftp.outboundGateway(ftpRemoteFileTemplate, AbstractRemoteFileOutboundGateway.Command.RM)
+      //  .fileNameExpression("headers['file_name']")
+      )
+      .get();
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ hibernateValidatorVersion=8.0.0.Final
 # Utilities
 reflectionsVersion=0.10.2
 springIntegrationSmbVersion=6.4.2
+springIntegrationFtpVersion=6.5.0
 jsoupVersion=1.15.4
 okhttpVersion=4.9.3
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * FTP 파일 업로드 및 삭제 기능이 추가되었습니다.
  * FTP 연동을 위한 환경설정 및 메시지 채널이 도입되었습니다.

* **기능 개선**
  * 기존 이미지 업로드 방식이 SMB에서 FTP로 변경되었습니다.
  * 새로 생성되는 아이템의 좋아요 수가 0으로 초기화됩니다.

* **버그 수정**
  * 에러 메시지 내 "SMB" 용어가 "FTP"로 수정되었습니다.

* **기타**
  * 관련 라이브러리 및 의존성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->