### PR TITLE
물품_등록에_대한_반환값에_등록한_물품_반환_필요

### DIFF
--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
@@ -68,7 +68,7 @@ public class ItemService {
 
   // 물품 등록
   @Transactional
-  public void postItem(ItemRequest request) {
+  public ItemResponse postItem(ItemRequest request) {
 
     Member member = request.getMember();
 
@@ -107,6 +107,10 @@ public class ItemService {
 
     // 아이템 임베딩 값 저장
     embeddingService.generateAndSaveItemEmbedding(extractItemText(savedItem), savedItem.getItemId());
+
+    return ItemResponse.builder()
+        .item(savedItem)
+        .build();
   }
 
   // 물품 수정

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemController.java
@@ -29,12 +29,11 @@ public class ItemController implements ItemControllerDocs {
   @Override
   @PostMapping(value = "/post", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @LogMonitor
-  public ResponseEntity<Void> postItem(
+  public ResponseEntity<ItemResponse> postItem(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @ModelAttribute ItemRequest request) {
     request.setMember(customUserDetails.getMember());
-    itemService.postItem(request);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.ok(itemService.postItem(request));
   }
 
   @Override

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemControllerDocs.java
@@ -13,6 +13,12 @@ public interface ItemControllerDocs {
 
   @ApiChangeLogs({
       @ApiChangeLog(
+          date = "2025.10.02",
+          author = Author.SUHSAECHAN,
+          issueNumber = 366,
+          description = "물품 등록 api 반환값 추가 item추가"
+      ),
+      @ApiChangeLog(
           date = "2025.09.18",
           author = Author.BAEKJIHOON,
           issueNumber = 336,
@@ -67,12 +73,12 @@ public interface ItemControllerDocs {
           - **`longitude`**: 거래 희망 위치 경도
           - **`latitude`**: 거래 희망 위치 위도
           - **`isAiPredictedPrice`**: AI 가격측정 여부
-          
-          ## 반환값
-          `없음`
+
+          ## 반환값 (ItemResponse)
+          - **`item`**: 생성된 물품 정보
           """
   )
-  ResponseEntity<Void> postItem(
+  ResponseEntity<ItemResponse> postItem(
       CustomUserDetails customUserDetails,
       ItemRequest request
   );


### PR DESCRIPTION
- #366 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 아이템 등록 API가 더 이상 빈 응답이 아닌 생성된 아이템 정보를 담은 응답 본문을 반환합니다. 등록 직후 아이템 ID와 주요 속성을 받아 리스트/상세 화면 갱신, 리다이렉션 등에 바로 활용할 수 있습니다.
- 문서
  - 아이템 등록 API의 반환 타입 변경을 반영하고, 응답 본문 구조와 예시를 업데이트했습니다. 변경 이력도 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->