### PR TITLE
채팅방별 읽지 않은 메시지 개수 제공 : refactor : 채팅중인 요청도 목록 조회에 추가 #318

### DIFF
--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/TradeRequestHistoryRepository.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/TradeRequestHistoryRepository.java
@@ -3,6 +3,8 @@ package com.romrom.item.repository.postgres;
 import com.romrom.common.constant.TradeStatus;
 import com.romrom.item.entity.postgres.Item;
 import com.romrom.item.entity.postgres.TradeRequestHistory;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -17,7 +19,7 @@ public interface TradeRequestHistoryRepository extends JpaRepository<TradeReques
 
   Optional<TradeRequestHistory> findByTakeItemAndGiveItem(Item takeItem, Item giveItem);
 
-  Page<TradeRequestHistory> findByTakeItemAndTradeStatus(Item takeItem, TradeStatus tradeStatus, Pageable pageable);
+  Page<TradeRequestHistory> findByTakeItemAndTradeStatusIn(Item takeItem, List<TradeStatus> tradeStatuses, Pageable pageable);
 
   Page<TradeRequestHistory> findByGiveItemAndTradeStatus(Item giveItem, TradeStatus tradeStatus, Pageable pageable);
 

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/TradeRequestService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/TradeRequestService.java
@@ -195,7 +195,7 @@ public class TradeRequestService {
 
     // 해당 물품이 받은 요청이면서 PENDING 상태인 TradeRequestHistory 조회 (페이징 적용)
     Page<TradeRequestHistory> tradeRequestHistoryPage = tradeRequestHistoryRepository
-        .findByTakeItemAndTradeStatus(takeItem, TradeStatus.PENDING, pageable);
+        .findByTakeItemAndTradeStatusIn(takeItem,  List.of(TradeStatus.PENDING, TradeStatus.CHATTING), pageable);
 
     return TradeResponse.builder()
         .tradeRequestHistoryPage(tradeRequestHistoryPage)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 수신한 거래 요청 목록에서 대기 중인 요청뿐만 아니라 협상 중인 요청도 함께 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->