### PR TITLE
물품_리스트_조회_API에서_ItemStatus_AVAILABLE_인_경우만_조회 : feat : 물품 리스트 조회 시 It…

### DIFF
--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/ItemRepositoryImpl.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/ItemRepositoryImpl.java
@@ -129,6 +129,7 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
     BooleanExpression where = QueryDslUtil.allOf(
         QueryDslUtil.neIfNotNull(ITEM.member.memberId, memberId),
         ITEM.isDeleted.isFalse(),
+        ITEM.itemStatus.eq(ItemStatus.AVAILABLE),
         notBlocked      // 차단 필터 적용
     );
 


### PR DESCRIPTION
…emStatus.AVAILABLE 인 물품만 반환 https://github.com/TEAM-ROMROM/RomRom-BE/issues/466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 아이템 필터링이 개선되어 가용 상태의 아이템만 검색 결과에 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->