### PR TITLE
20260209 #491 채팅방 페이지에서 각각 채팅방과 연관된 물품의 이미지 url 전송 필요

### DIFF
--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatControllerDocs.java
@@ -35,9 +35,10 @@ public interface ChatControllerDocs {
     - 각 채팅방은 chatRoomType (RECEIVED/REQUESTED)을 포함하여 보낸 요청/받은 요청 구분이 가능합니다.
 
     ### 반환값 (ChatRoomResponse)
-    - `chatRoomDetailDtoSlice` (Slice<ChatRoomDetailDto>): 내가 참여 중인 채팅방 목록과 각 방의 세부 정보 (위치, 마지막 메시지 등)
+    - `chatRoomDetailDtoPage` (Slice<ChatRoomDetailDto>): 내가 참여 중인 채팅방 목록과 각 방의 세부 정보 (위치, 마지막 메시지 등)
     아래는 ChatRoomDetailDto 정보입니다.
     - `chatRoomId` (UUID) : 채팅방 ID
+    - `blocked` (boolean) : 차단 여부 (내가 상대방을 차단했거나 상대방이 나를 차단한 경우 true)
     - `targetMember` (Member) : 상대방 정보
     - `targetMemberEupMyeonDong` (String) : 상대방 위치 (읍면동)
     - `lastMessageContent` (String) : 마지막 메시지 내용


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 채팅방 목록에 상대방의 아이템 이미지 표시 기능 추가
  * 채팅방 차단 상태 정보 표시 기능 추가

* **문서**
  * API 응답 구조 개선 및 필드 정보 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->