### PR TITLE
거래요청_삭제_API_구현_필요

### DIFF
--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/TradeController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/TradeController.java
@@ -68,7 +68,6 @@ public class TradeController implements TradeControllerDocs {
     return ResponseEntity.ok().build();
   }
 
-  // TODO : 거래요청 삭제 API 필요
   @Override
   @PostMapping(value = "/delete", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @LogMonitor
@@ -80,7 +79,16 @@ public class TradeController implements TradeControllerDocs {
     return ResponseEntity.ok().build();
   }
 
-  // TODO : 거래취소 API랑 합치기 고려
+  @Override
+  @PostMapping(value = "/reject", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @LogMonitor
+  public ResponseEntity<Void> rejectTradeRequest(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @ModelAttribute TradeRequest request) {
+    request.setMember(customUserDetails.getMember());
+    tradeRequestService.rejectTradeRequest(request);
+    return ResponseEntity.ok().build();
+  }
   @Override
   @PostMapping(value = "/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @LogMonitor

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/TradeControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/TradeControllerDocs.java
@@ -267,6 +267,32 @@ public interface TradeControllerDocs {
   ResponseEntity<Void> cancelTradeRequest(CustomUserDetails customUserDetails, TradeRequest tradeRequest);
 
   @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.02.10", author = Author.SUHSAECHAN, issueNumber = 497, description = "거래 요청 거절(물리 삭제) API 구현"),
+  })
+  @Operation(
+      summary = "거래 요청 거절 (물리 삭제)",
+      description = """
+          ## 인증(JWT): **필요**
+
+          ## 요청 파라미터 (TradeRequest)
+          - **`tradeRequestHistoryId`**: 거래 요청 ID (UUID)
+
+          ## 반환값 (Void)
+
+          ## 에러코드
+          - **`TRADE_REQUEST_NOT_FOUND`**: 해당 거래 요청이 존재하지 않습니다.
+          - **`INVALID_ITEM_OWNER`**: 거래 요청을 받은 물품의 소유주가 아닙니다.
+          - **`TRADE_ALREADY_PROCESSED`**: 이미 처리(완료, 취소, 채팅중)된 거래 요청입니다.
+
+          ## 설명
+          - 거래 요청을 받은 사람(takeItem 소유자)만 거절 가능
+          - PENDING 상태에서만 거절 가능 (채팅이 시작된 경우 거절 불가)
+          - 거절 시 DB에서 물리적으로 삭제 (상태 변경이 아닌 row 삭제)
+          """
+  )
+  ResponseEntity<Void> rejectTradeRequest(CustomUserDetails customUserDetails, TradeRequest tradeRequest);
+
+  @ApiChangeLogs({
       @ApiChangeLog(date = "2026.01.03", author = Author.WISEUNGJAE, issueNumber = 428, description = "차단된 회원과의 거래 요청 수정을 방지하는 검증 로직 추가"),
       @ApiChangeLog(date = "2025.09.11", author = Author.KIMNAYOUNG, issueNumber = 301, description = "거래 요청 수정"),
   })


### PR DESCRIPTION
- #497 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **새로운 기능**
  * 거래 요청 거절 기능이 추가되었습니다. 받을 물품의 소유자가 대기 중인 거래 요청을 거절할 수 있으며, 거절 시 해당 거래 요청이 시스템에서 완전히 제거됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->