### PR TITLE
FCM_알림_히스토리가_로그_상으론_저장되었으나_실제_DB에는_저장되지_않음 : feat : notification_hist…

### DIFF
--- a/RomRom-Domain-Notification/src/main/java/com/romrom/notification/entity/NotificationHistory.java
+++ b/RomRom-Domain-Notification/src/main/java/com/romrom/notification/entity/NotificationHistory.java
@@ -54,7 +54,7 @@ public class NotificationHistory extends BasePostgresEntity {
   @Column(nullable = false)
   private String body;
 
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "TEXT")
   @Convert(converter = NotificationPayloadConverter.class)
   private Map<String, String> payload;
 

--- a/RomRom-Web/src/main/resources/db/migration/V1_4_19__alter_notification_history_payload_to_text.sql
+++ b/RomRom-Web/src/main/resources/db/migration/V1_4_19__alter_notification_history_payload_to_text.sql
@@ -1,0 +1,23 @@
+-- notification_history 테이블의 payload 컬럼을 VARCHAR(255) -> TEXT로 변경
+-- 알림 payload(JSON)가 255자를 초과할 수 있어 TEXT 타입으로 변경
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'notification_history'
+    ) AND EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'notification_history' AND column_name = 'payload'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE notification_history ALTER COLUMN payload TYPE TEXT;
+        RAISE NOTICE 'notification_history: payload 컬럼 VARCHAR(255) → TEXT 변경 완료';
+    ELSE
+        RAISE NOTICE 'notification_history: payload 컬럼이 이미 TEXT이거나 테이블이 없습니다.';
+    END IF;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'notification_history payload 컬럼 변경 중 오류 발생: %', SQLERRM;
+END $$;


### PR DESCRIPTION
…ory 테이블 payload 컬럼 TEXT 타입으로 수정 https://github.com/TEAM-ROMROM/RomRom-BE/issues/527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  - 알림 페이로드의 데이터 저장 용량이 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->