### PR TITLE
WEBP_변환_시_EXIF_orientation_미반영으로_사진이_회전되어_저장되는_문제 : feat : WebP 변환 시 …

### DIFF
--- a/RomRom-Common/src/main/java/com/romrom/common/service/ImageCompressionService.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/service/ImageCompressionService.java
@@ -2,9 +2,8 @@ package com.romrom.common.service;
 
 import com.romrom.common.dto.CompressedImage;
 import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.nio.ByteArrayImageSource;
 import com.sksamuel.scrimage.webp.WebpWriter;
-import java.awt.image.BufferedImage;
-import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,20 +34,14 @@ public class ImageCompressionService {
     try {
       long originalSize = file.getSize();
 
-      // 이미지 읽기
-      BufferedImage originalImage = ImageIO.read(file.getInputStream());
-      if (originalImage == null) {
-        log.warn("이미지 읽기 실패: {}", file.getOriginalFilename());
-        return null;
-      }
-
-      // ImmutableImage로 변환
-      ImmutableImage image = ImmutableImage.fromAwt(originalImage);
+      // 이미지 읽기 (EXIF orientation 자동 적용)
+      ImmutableImage image = ImmutableImage.loader().load(new ByteArrayImageSource(file.getBytes()));
 
       // 가로 기준 리사이즈 (비율 유지, 큰 이미지만)
       if (image.width > TARGET_WIDTH) {
+        int originalWidth = image.width;
         image = image.scaleToWidth(TARGET_WIDTH);
-        log.debug("이미지 리사이즈: {} -> {}", originalImage.getWidth(), TARGET_WIDTH);
+        log.debug("이미지 리사이즈: {} -> {}", originalWidth, TARGET_WIDTH);
       }
 
       // WebP로 변환


### PR DESCRIPTION
…EXIF orientation 자동 적용 https://github.com/TEAM-ROMROM/RomRom-BE/issues/526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 이미지 파일의 EXIF 방향 정보가 로드 중에 자동으로 올바르게 처리되도록 개선했습니다.

* **기타 개선**
  * 이미지 압축 서비스의 로딩 프로세스를 최적화했습니다.
  * 이미지 리사이징 로그가 원본 이미지 크기를 정확하게 기록합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->