### PR TITLE
오픈_API_HMAC_Timestamp_기반_보안_강화_공통_모듈_구현

### DIFF
--- a/RomRom-Common/src/main/java/com/romrom/common/annotation/SecuredApi.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/annotation/SecuredApi.java
@@ -1,0 +1,17 @@
+package com.romrom.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 오픈 API에 HMAC + Timestamp 기반 서명 검증을 적용하는 어노테이션
+ * 클래스 레벨 또는 메서드 레벨에 적용 가능
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SecuredApi {
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/aop/SecuredApiAspect.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/aop/SecuredApiAspect.java
@@ -1,0 +1,83 @@
+package com.romrom.common.aop;
+
+import com.romrom.common.annotation.SecuredApi;
+import com.romrom.common.properties.SecuredApiProperties;
+import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.ErrorCode;
+import com.romrom.common.util.SignatureUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * @SecuredApi 어노테이션이 적용된 API에 대해 HMAC + Timestamp 서명 검증을 수행하는 AOP Aspect
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@EnableConfigurationProperties(SecuredApiProperties.class)
+@Slf4j
+public class SecuredApiAspect {
+
+  private static final String HEADER_SIGNATURE = "X-Signature";
+  private static final String HEADER_TIMESTAMP = "X-Timestamp";
+
+  private final SecuredApiProperties securedApiProperties;
+
+  @Around("@annotation(com.romrom.common.annotation.SecuredApi) || "
+      + "(@within(com.romrom.common.annotation.SecuredApi) "
+      + "&& !@annotation(com.romrom.common.annotation.SecuredApi))")
+  public Object verifySignature(ProceedingJoinPoint joinPoint) throws Throwable {
+    HttpServletRequest request = getCurrentHttpRequest();
+
+    String signature = request.getHeader(HEADER_SIGNATURE);
+    String timestamp = request.getHeader(HEADER_TIMESTAMP);
+
+    // 헤더 누락 검증
+    if (signature == null || signature.isBlank() || timestamp == null || timestamp.isBlank()) {
+      log.warn("SecuredApi 서명 헤더 누락 - URI: {}", request.getRequestURI());
+      throw new CustomException(ErrorCode.MISSING_SIGNATURE_HEADER);
+    }
+
+    // Timestamp 만료 검증 (양방향: 클라이언트 시계 오차 허용)
+    long requestTimestamp;
+    try {
+      requestTimestamp = Long.parseLong(timestamp);
+    } catch (NumberFormatException e) {
+      log.warn("SecuredApi 타임스탬프 형식 오류 - timestamp: {}", timestamp);
+      throw new CustomException(ErrorCode.EXPIRED_SIGNATURE_TIMESTAMP);
+    }
+
+    long currentTime = System.currentTimeMillis();
+    if (Math.abs(currentTime - requestTimestamp) > securedApiProperties.getExpirationTime()) {
+      log.warn("SecuredApi 타임스탬프 만료 - 요청: {}, 현재: {}, 차이: {}ms",
+          requestTimestamp, currentTime, Math.abs(currentTime - requestTimestamp));
+      throw new CustomException(ErrorCode.EXPIRED_SIGNATURE_TIMESTAMP);
+    }
+
+    // HMAC 서명 검증
+    if (!SignatureUtil.verifySignature(timestamp, securedApiProperties.getSecretKey(), signature)) {
+      log.warn("SecuredApi 서명 불일치 - URI: {}", request.getRequestURI());
+      throw new CustomException(ErrorCode.INVALID_SIGNATURE);
+    }
+
+    log.debug("SecuredApi 검증 통과 - URI: {}", request.getRequestURI());
+    return joinPoint.proceed();
+  }
+
+  private HttpServletRequest getCurrentHttpRequest() {
+    ServletRequestAttributes attributes =
+        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+    if (attributes == null) {
+      throw new CustomException(ErrorCode.INVALID_REQUEST);
+    }
+    return attributes.getRequest();
+  }
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
@@ -198,6 +198,11 @@ public enum ErrorCode {
   MINIO_PRESIGNED_URL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MinIO Presigned URL 생성에 실패했습니다."),
   MINIO_INVALID_BUCKET_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 MinIO 버킷 이름입니다."),
   MINIO_INVALID_OBJECT_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 MinIO 오브젝트 이름입니다."),
+
+  // SECURED API
+  MISSING_SIGNATURE_HEADER(HttpStatus.UNAUTHORIZED, "서명 헤더가 누락되었습니다."),
+  EXPIRED_SIGNATURE_TIMESTAMP(HttpStatus.UNAUTHORIZED, "요청 타임스탬프가 만료되었습니다."),
+  INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "유효하지 않은 서명입니다."),
   ;
 
   private final HttpStatus status;

--- a/RomRom-Common/src/main/java/com/romrom/common/properties/SecuredApiProperties.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/properties/SecuredApiProperties.java
@@ -1,0 +1,24 @@
+package com.romrom.common.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * SecuredApi 서명 검증 설정
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "secured-api")
+public class SecuredApiProperties {
+
+  /**
+   * HMAC 서명용 Secret Key
+   */
+  private String secretKey;
+
+  /**
+   * 타임스탬프 만료 시간 (밀리초, 기본값: 5분)
+   */
+  private long expirationTime = 300000L;
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/util/SignatureUtil.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/util/SignatureUtil.java
@@ -1,0 +1,66 @@
+package com.romrom.common.util;
+
+import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.ErrorCode;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * HMAC-SHA256 서명 생성 및 검증 유틸리티
+ */
+@Slf4j
+public class SignatureUtil {
+
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+  /**
+   * HMAC-SHA256 서명 생성
+   *
+   * @param timestamp 타임스탬프 문자열
+   * @param secretKey Secret Key
+   * @return Hex 인코딩된 HMAC-SHA256 서명
+   */
+  public static String generateSignature(String timestamp, String secretKey) {
+    try {
+      Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+      SecretKeySpec keySpec = new SecretKeySpec(
+          secretKey.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
+      mac.init(keySpec);
+      byte[] hash = mac.doFinal(timestamp.getBytes(StandardCharsets.UTF_8));
+      return bytesToHex(hash);
+    } catch (Exception e) {
+      log.error("서명 생성 실패: {}", e.getMessage());
+      throw new CustomException(ErrorCode.INVALID_SIGNATURE);
+    }
+  }
+
+  /**
+   * HMAC-SHA256 서명 검증 (constant-time 비교로 timing attack 방지)
+   *
+   * @param timestamp 타임스탬프 문자열
+   * @param secretKey Secret Key
+   * @param signature 클라이언트가 전달한 서명
+   * @return 서명 일치 여부
+   */
+  public static boolean verifySignature(String timestamp, String secretKey, String signature) {
+    String expected = generateSignature(timestamp, secretKey);
+    return MessageDigest.isEqual(
+        expected.getBytes(StandardCharsets.UTF_8),
+        signature.getBytes(StandardCharsets.UTF_8)
+    );
+  }
+
+  /**
+   * 바이트 배열을 Hex 문자열로 변환
+   */
+  private static String bytesToHex(byte[] bytes) {
+    StringBuilder sb = new StringBuilder();
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+}

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/SecurityUrls.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/SecurityUrls.java
@@ -20,9 +20,6 @@ public class SecurityUrls {
     "/api/auth/login",   // Firebase 통합 로그인
     "/api/auth/reissue", // accessToken 재발급
 
-    // app
-    "/api/app/version/check", // 앱 버전 체크 (인증 불필요)
-
     // test-api
     "/api/test/sign-up", // 테스트 회원가입
     "/api/test/send/notification/all", // 테스트 전체 알람 발송
@@ -54,6 +51,14 @@ public class SecurityUrls {
     "/api/admin/login",
     "/api/admin/logout"
 
+  );
+
+  /**
+   * HMAC + Timestamp 서명 검증이 필요한 오픈 API URL 패턴 목록
+   * JWT 인증은 스킵하고, @SecuredApi AOP에서 HMAC 서명 검증을 수행
+   */
+  public static final List<String> SECURED_API_URLS = Arrays.asList(
+    "/api/app/version/check"  // 앱 버전 체크
   );
 
   /**

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/filter/TokenAuthenticationFilter.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/filter/TokenAuthenticationFilter.java
@@ -153,6 +153,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
    */
   private boolean isWhitelistedPath(String uri) {
     return SecurityUrls.AUTH_WHITELIST.stream()
+        .anyMatch(pattern -> pathMatcher.match(pattern, uri))
+        || SecurityUrls.SECURED_API_URLS.stream()
         .anyMatch(pattern -> pathMatcher.match(pattern, uri));
   }
 

--- a/RomRom-Web/src/main/java/com/romrom/web/config/SecurityConfig.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/config/SecurityConfig.java
@@ -60,6 +60,8 @@ public class SecurityConfig {
         .authorizeHttpRequests((authorize) -> authorize
             .requestMatchers(SecurityUrls.AUTH_WHITELIST.toArray(new String[0]))
             .permitAll() // AUTH_WHITELIST에 등록된 URL은 인증 허용 (우선 적용)
+            .requestMatchers(SecurityUrls.SECURED_API_URLS.toArray(new String[0]))
+            .permitAll() // SECURED_API_URLS: JWT 스킵, @SecuredApi AOP에서 HMAC 서명 검증
             .requestMatchers(SecurityUrls.ADMIN_PATHS.toArray(new String[0]))
             .hasRole("ADMIN") // ADMIN_PATHS에 등록된 URL은 관리자만 접근가능
             .anyRequest().authenticated()


### PR DESCRIPTION
- https://github.com/TEAM-ROMROM/RomRom-BE/issues/575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * HMAC 서명 및 타임스탬프 기반 API 보안 인증 메커니즘 추가
  * 보안이 필요한 API 엔드포인트에 서명 검증 기능 적용
  * 만료된 요청 거부 및 서명 유효성 검증 기능 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->