### PR TITLE
동일_이메일로_다른_소셜_플랫폼_로그인_시_Provider_구분_없이_로그인_처리됨 

### DIFF
--- a/RomRom-Common/src/main/java/com/romrom/common/exception/EmailAlreadyRegisteredException.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/EmailAlreadyRegisteredException.java
@@ -1,0 +1,15 @@
+package com.romrom.common.exception;
+
+import com.romrom.common.constant.SocialPlatform;
+import lombok.Getter;
+
+@Getter
+public class EmailAlreadyRegisteredException extends CustomException {
+
+  private final SocialPlatform registeredSocialPlatform;
+
+  public EmailAlreadyRegisteredException(SocialPlatform registeredSocialPlatform) {
+    super(ErrorCode.EMAIL_ALREADY_REGISTERED);
+    this.registeredSocialPlatform = registeredSocialPlatform;
+  }
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/exception/EmailAlreadyRegisteredResponse.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/EmailAlreadyRegisteredResponse.java
@@ -1,0 +1,16 @@
+package com.romrom.common.exception;
+
+import com.romrom.common.constant.SocialPlatform;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class EmailAlreadyRegisteredResponse {
+
+  private String errorCode;
+
+  private SocialPlatform registeredSocialPlatform;
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
 
   EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
 
+  EMAIL_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 다른 소셜 플랫폼으로 가입된 이메일입니다."),
+
   DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
 
   INVALID_REQUIRED_TERMS_AGREED(HttpStatus.BAD_REQUEST, "필수 이용약관에 동의하지 않았습니다."),

--- a/RomRom-Common/src/main/java/com/romrom/common/exception/controller/GlobalExceptionHandler.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/controller/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.romrom.common.exception.controller;
 
 import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.EmailAlreadyRegisteredException;
+import com.romrom.common.exception.EmailAlreadyRegisteredResponse;
 import com.romrom.common.exception.ErrorCode;
 import com.romrom.common.exception.ErrorResponse;
 import com.romrom.common.exception.SuspendedMemberException;
@@ -28,6 +30,18 @@ public class GlobalExceptionHandler {
         .suspendedUntil(e.getSuspendedUntil())
         .build();
     return ResponseEntity.status(ErrorCode.SUSPENDED_MEMBER.getStatus()).body(suspendedMemberResponse);
+  }
+
+  @ExceptionHandler(EmailAlreadyRegisteredException.class)
+  public ResponseEntity<EmailAlreadyRegisteredResponse> handleEmailAlreadyRegisteredException(
+      EmailAlreadyRegisteredException e) {
+    log.warn("이메일 중복 소셜 플랫폼 로그인 시도: registeredSocialPlatform={}", e.getRegisteredSocialPlatform());
+    EmailAlreadyRegisteredResponse emailAlreadyRegisteredResponse = EmailAlreadyRegisteredResponse.builder()
+        .errorCode(ErrorCode.EMAIL_ALREADY_REGISTERED.name())
+        .registeredSocialPlatform(e.getRegisteredSocialPlatform())
+        .build();
+    return ResponseEntity.status(ErrorCode.EMAIL_ALREADY_REGISTERED.getStatus())
+        .body(emailAlreadyRegisteredResponse);
   }
 
   @ExceptionHandler(UgcProhibitedContentException.class)

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/AuthService.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import com.romrom.common.constant.AccountStatus;
 import com.romrom.common.constant.Role;
 import com.romrom.common.constant.SocialPlatform;
 import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.EmailAlreadyRegisteredException;
 import com.romrom.common.exception.ErrorCode;
 import com.romrom.common.exception.SuspendedMemberException;
 import com.romrom.member.entity.Member;
@@ -64,6 +65,9 @@ public class AuthService {
     Member member;
     if (existMember.isPresent()) {
       member = existMember.get();
+      if (member.getSocialPlatform() != socialPlatform) {
+        throw new EmailAlreadyRegisteredException(member.getSocialPlatform());
+      }
       member.setIsFirstLogin(false);
     } else { // 신규 회원
       member = Member.builder()

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthControllerDocs.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 public interface AuthControllerDocs {
 
   @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.03.27", author = Author.SUHSAECHAN, issueNumber = 605, description = "동일 이메일 다른 소셜 플랫폼 로그인 시 409 에러 응답 추가"),
       @ApiChangeLog(date = "2026.03.05", author = Author.WISEUNGJAE, issueNumber = 561, description = "Firebase Authentication 기반 통합 로그인으로 전환, 기존 /sign-in 제거"),
       @ApiChangeLog(date = "2026.01.13", author = Author.WISEUNGJAE, issueNumber = 446, description = "회원가입 시 알림수신여부 false로 초기화"),
       @ApiChangeLog(date = "2025.04.07", author = Author.WISEUNGJAE, issueNumber = 90, description = "소셜 로그인 시 nickname 제거 후 랜덤 닉네임 지정"),
@@ -56,6 +57,7 @@ public interface AuthControllerDocs {
       - **`INVALID_FIREBASE_TOKEN`**: 유효하지 않은 Firebase 인증 토큰입니다.
       - **`EXPIRED_FIREBASE_TOKEN`**: 만료된 Firebase 인증 토큰입니다.
       - **`INVALID_SOCIAL_PLATFORM`**: 지원하지 않는 소셜 로그인 제공자입니다.
+      - **`EMAIL_ALREADY_REGISTERED`**: 이미 다른 소셜 플랫폼으로 가입된 이메일입니다. (409 + EmailAlreadyRegisteredResponse: errorCode, registeredSocialPlatform)
       """
   )
   ResponseEntity<AuthResponse> login(LoginRequest request);


### PR DESCRIPTION
- https://github.com/TEAM-ROMROM/RomRom-BE/issues/605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 소셜 로그인 시 이메일이 다른 플랫폼에 이미 가입되어 있는 경우 감지 및 처리 기능 추가
  * 사용자가 이메일 중복 등록 시 기존 등록 플랫폼 정보 제공

* **개선**
  * 크로스 플랫폼 이메일 충돌에 대한 명확한 에러 응답(409 Conflict) 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->