### PR TITLE
테스트_빌드용_SSE_서버_로그_스트리밍_엔드포인트_추가

### DIFF
--- a/RomRom-Common/src/main/java/com/romrom/common/dto/DebugLogEvent.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/dto/DebugLogEvent.java
@@ -1,0 +1,27 @@
+package com.romrom.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * SSE 로그 스트리밍용 로그 이벤트 DTO
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class DebugLogEvent {
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+  private final LocalDateTime timestamp;
+
+  private final String level;
+
+  private final String loggerName;
+
+  private final String message;
+
+  private final String threadName;
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/logging/SseLogAppender.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/logging/SseLogAppender.java
@@ -1,0 +1,61 @@
+package com.romrom.common.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import com.romrom.common.dto.DebugLogEvent;
+import com.romrom.common.service.SseLogBroadcaster;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Logback 커스텀 Appender — 로그 이벤트를 SSE 구독자에게 발행
+ * com.romrom 패키지 로그만 필터링하여 전송
+ */
+public class SseLogAppender extends AppenderBase<ILoggingEvent> {
+
+  private static final String TARGET_LOGGER_PREFIX = "com.romrom";
+
+  private static volatile ApplicationContext applicationContext;
+  private volatile SseLogBroadcaster sseLogBroadcaster;
+
+  /**
+   * Spring ApplicationContext 설정 (ApplicationContextAware 또는 초기화 시 호출)
+   */
+  public static void setApplicationContext(ApplicationContext applicationContext) {
+    SseLogAppender.applicationContext = applicationContext;
+  }
+
+  @Override
+  protected void append(ILoggingEvent loggingEvent) {
+    // com.romrom 패키지 로그만 처리
+    if (!loggingEvent.getLoggerName().startsWith(TARGET_LOGGER_PREFIX)) {
+      return;
+    }
+
+    // 지연 초기화: Spring Context가 준비된 후 빈 조회
+    if (sseLogBroadcaster == null) {
+      if (applicationContext == null) {
+        return;
+      }
+      try {
+        sseLogBroadcaster = applicationContext.getBean(SseLogBroadcaster.class);
+      } catch (Exception e) {
+        return;
+      }
+    }
+
+    DebugLogEvent debugLogEvent = DebugLogEvent.builder()
+        .timestamp(LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(loggingEvent.getTimeStamp()),
+            ZoneId.systemDefault()))
+        .level(loggingEvent.getLevel().toString())
+        .loggerName(loggingEvent.getLoggerName())
+        .message(loggingEvent.getFormattedMessage())
+        .threadName(loggingEvent.getThreadName())
+        .build();
+
+    sseLogBroadcaster.broadcast(debugLogEvent);
+  }
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/logging/SseLogAppenderInitializer.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/logging/SseLogAppenderInitializer.java
@@ -1,0 +1,19 @@
+package com.romrom.common.logging;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Context 초기화 시 SseLogAppender에 ApplicationContext를 주입
+ */
+@Component
+public class SseLogAppenderInitializer implements ApplicationListener<ContextRefreshedEvent> {
+
+  @Override
+  public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
+    ApplicationContext applicationContext = contextRefreshedEvent.getApplicationContext();
+    SseLogAppender.setApplicationContext(applicationContext);
+  }
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/service/SseLogBroadcaster.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/service/SseLogBroadcaster.java
@@ -1,0 +1,123 @@
+package com.romrom.common.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.romrom.common.dto.DebugLogEvent;
+import java.io.IOException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * SSE 로그 스트리밍 구독자 관리 및 브로드캐스트
+ * - 최대 동시 구독자: 10
+ * - 초당 로그 이벤트 제한: 100건
+ */
+@Component
+@Slf4j
+public class SseLogBroadcaster {
+
+  private static final int MAX_SUBSCRIBERS = 10;
+  private static final int MAX_EVENTS_PER_SECOND = 100;
+
+  private final CopyOnWriteArrayList<SseEmitter> debugLogSubscribers = new CopyOnWriteArrayList<>();
+  private final ObjectMapper debugLogObjectMapper;
+
+  private final AtomicInteger eventsInCurrentSecond = new AtomicInteger(0);
+  private final AtomicLong currentSecondTimestamp = new AtomicLong(0);
+  private final AtomicInteger skippedEventCount = new AtomicInteger(0);
+
+  public SseLogBroadcaster() {
+    this.debugLogObjectMapper = new ObjectMapper();
+    this.debugLogObjectMapper.registerModule(new JavaTimeModule());
+  }
+
+  /**
+   * SSE 구독자 등록
+   * @return 등록 성공 여부 (최대 구독자 초과 시 false)
+   */
+  public boolean addSubscriber(SseEmitter sseLogEmitter) {
+    if (debugLogSubscribers.size() >= MAX_SUBSCRIBERS) {
+      log.warn("SSE 로그 스트리밍 최대 구독자 수 초과: {}/{}", debugLogSubscribers.size(), MAX_SUBSCRIBERS);
+      return false;
+    }
+    debugLogSubscribers.add(sseLogEmitter);
+    log.info("SSE 로그 스트리밍 구독자 등록 (현재: {}명)", debugLogSubscribers.size());
+    return true;
+  }
+
+  /**
+   * SSE 구독자 제거
+   */
+  public void removeSubscriber(SseEmitter sseLogEmitter) {
+    debugLogSubscribers.remove(sseLogEmitter);
+    log.info("SSE 로그 스트리밍 구독자 제거 (현재: {}명)", debugLogSubscribers.size());
+  }
+
+  /**
+   * 모든 구독자에게 로그 이벤트 브로드캐스트
+   * - 초당 약 100건 제한 (근사치 rate limiting — 멀티스레드 환경에서 정확한 초당 제한이 아닌 대략적 제한)
+   * - 초과 시 건너뛰고 "[N건 생략]" 메시지 전송
+   */
+  public void broadcast(DebugLogEvent debugLogEvent) {
+    if (debugLogSubscribers.isEmpty()) {
+      return;
+    }
+
+    // Rate limiting: 초당 이벤트 수 체크
+    long nowSeconds = System.currentTimeMillis() / 1000;
+    long previousSecond = currentSecondTimestamp.getAndSet(nowSeconds);
+    if (nowSeconds != previousSecond) {
+      // 새로운 초가 시작됨 — 생략된 건수가 있으면 알림 전송
+      int skippedInPreviousSecond = skippedEventCount.getAndSet(0);
+      if (skippedInPreviousSecond > 0) {
+        sendSkippedNotification(skippedInPreviousSecond);
+      }
+      eventsInCurrentSecond.set(0);
+    }
+
+    if (eventsInCurrentSecond.incrementAndGet() > MAX_EVENTS_PER_SECOND) {
+      skippedEventCount.incrementAndGet();
+      return;
+    }
+
+    String debugLogJson;
+    try {
+      debugLogJson = debugLogObjectMapper.writeValueAsString(debugLogEvent);
+    } catch (IOException e) {
+      return;
+    }
+
+    for (SseEmitter subscriberEmitter : debugLogSubscribers) {
+      try {
+        subscriberEmitter.send(SseEmitter.event().data(debugLogJson));
+      } catch (IOException e) {
+        debugLogSubscribers.remove(subscriberEmitter);
+      }
+    }
+  }
+
+  /**
+   * 생략된 로그 건수 알림 전송
+   */
+  private void sendSkippedNotification(int skippedLogCount) {
+    String skippedMessage = String.format("{\"level\":\"WARN\",\"message\":\"[%d건 생략 — rate limit 초과]\"}", skippedLogCount);
+    for (SseEmitter subscriberEmitter : debugLogSubscribers) {
+      try {
+        subscriberEmitter.send(SseEmitter.event().data(skippedMessage));
+      } catch (IOException e) {
+        debugLogSubscribers.remove(subscriberEmitter);
+      }
+    }
+  }
+
+  /**
+   * 현재 활성 구독자 수 반환
+   */
+  public int getActiveSubscriberCount() {
+    return debugLogSubscribers.size();
+  }
+}

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/SecurityUrls.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/SecurityUrls.java
@@ -62,7 +62,8 @@ public class SecurityUrls {
    */
   public static final List<String> SECURED_API_URLS = Arrays.asList(
     "/api/app/version/check",   // 앱 버전 체크
-    "/api/app/version/update"   // 앱 최신 버전 업데이트 (CI/CD)
+    "/api/app/version/update",  // 앱 최신 버전 업데이트 (CI/CD)
+    "/api/app/debug/log-stream" // SSE 로그 스트리밍 (테스트 빌드 디버그)
   );
 
   /**

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugController.java
@@ -1,0 +1,60 @@
+package com.romrom.web.controller.api;
+
+import com.romrom.common.annotation.SecuredApi;
+import com.romrom.common.service.SseLogBroadcaster;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * 디버그용 SSE 로그 스트리밍 엔드포인트
+ * 테스트 빌드에서 앱 내 플로팅 버튼으로 서버 로그를 실시간 확인
+ */
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "디버그 API", description = "테스트 빌드용 디버그 도구 API")
+@RequestMapping("/api/app")
+@Slf4j
+public class DebugController implements DebugControllerDocs {
+
+  private static final long SSE_LOG_STREAM_TIMEOUT = 300_000L; // 5분
+
+  private final SseLogBroadcaster sseLogBroadcaster;
+
+  @Override
+  @GetMapping(value = "/debug/log-stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  @SecuredApi
+  public SseEmitter streamDebugLog() {
+    SseEmitter debugLogEmitter = new SseEmitter(SSE_LOG_STREAM_TIMEOUT);
+
+    boolean isSubscriberRegistered = sseLogBroadcaster.addSubscriber(debugLogEmitter);
+    if (!isSubscriberRegistered) {
+      throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "최대 동시 접속 수 초과");
+    }
+
+    // 연결 종료 시 구독자 제거 (onTimeout/onError → complete() → onCompletion 순서로 호출됨)
+    debugLogEmitter.onCompletion(() -> {
+      sseLogBroadcaster.removeSubscriber(debugLogEmitter);
+      log.debug("SSE 로그 스트리밍 연결 종료");
+    });
+    debugLogEmitter.onTimeout(() -> {
+      log.debug("SSE 로그 스트리밍 타임아웃 (5분)");
+      debugLogEmitter.complete();
+    });
+    debugLogEmitter.onError(throwable -> {
+      log.debug("SSE 로그 스트리밍 에러: {}", throwable.getMessage());
+      debugLogEmitter.complete();
+    });
+
+    log.info("SSE 로그 스트리밍 연결 수립 (활성 구독자: {}명)", sseLogBroadcaster.getActiveSubscriberCount());
+
+    return debugLogEmitter;
+  }
+}

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugControllerDocs.java
@@ -1,0 +1,54 @@
+package com.romrom.web.controller.api;
+
+import com.romrom.common.dto.Author;
+import io.swagger.v3.oas.annotations.Operation;
+import me.suhsaechan.suhapilog.annotation.ApiChangeLog;
+import me.suhsaechan.suhapilog.annotation.ApiChangeLogs;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface DebugControllerDocs {
+
+  @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.03.27", author = Author.SUHSAECHAN, issueNumber = 607, description = "SSE 서버 로그 스트리밍 디버그 엔드포인트 추가"),
+  })
+  @Operation(
+      summary = "서버 로그 실시간 스트리밍 (SSE)",
+      description = """
+      ## 인증: **@SecuredApi** (HMAC + Timestamp)
+
+      ## 요청 헤더
+      - **`X-Timestamp`**: 밀리초 단위 타임스탬프
+      - **`X-Signature`**: HMAC-SHA256(timestamp, secretKey) Hex 인코딩
+
+      ## 반환값
+      - **Content-Type**: `text/event-stream`
+      - SSE 스트림으로 서버 로그 이벤트를 실시간 전송
+
+      ## SSE 이벤트 포맷
+      ```json
+      {
+        "timestamp": "2026-03-27T14:30:00.123",
+        "level": "DEBUG",
+        "loggerName": "com.romrom.web.controller.api.ItemController",
+        "message": "물품 조회 요청 - memberId: 123",
+        "threadName": "http-nio-8080-exec-1"
+      }
+      ```
+
+      ## 동작 설명
+      - 연결 후 서버의 전체 애플리케이션 로그(DEBUG/INFO/WARN/ERROR)를 실시간 스트리밍
+      - com.romrom 패키지 로그만 전송 (프레임워크 로그 제외)
+      - 5분(300초) 후 자동 연결 종료 (서버 리소스 보호)
+      - 클라이언트가 연결을 종료하면 즉시 정리
+      - 최대 동시 접속: 10명
+      - 초당 최대 100건 (초과 시 "[N건 생략]" 메시지 전송)
+
+      ## 에러코드
+      - MISSING_SIGNATURE_HEADER (401): 서명 헤더 누락
+      - EXPIRED_SIGNATURE_TIMESTAMP (401): 타임스탬프 만료
+      - INVALID_SIGNATURE (401): 유효하지 않은 서명
+      - 503: 최대 동시 접속 초과
+      """
+  )
+  SseEmitter streamDebugLog();
+}

--- a/RomRom-Web/src/main/resources/logback-spring.xml
+++ b/RomRom-Web/src/main/resources/logback-spring.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <!-- Spring Boot 기본 logback 설정 포함 (console, file 등) -->
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+  <!-- application.yml의 logging.file.name 프로퍼티 사용 -->
+  <springProperty scope="context" name="LOG_FILE" source="logging.file.name" defaultValue="romrom.log"/>
+
+  <!-- 파일 Appender (기존 application.yml 설정 반영) -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_FILE}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+      <maxFileSize>100MB</maxFileSize>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- SSE 로그 스트리밍 Appender -->
+  <appender name="SSE_LOG" class="com.romrom.common.logging.SseLogAppender"/>
+
+  <!-- 프레임워크 로그 레벨 (기존 application.yml 설정 유지, application.yml의 logging.level.*이 추가로 오버라이드 가능) -->
+  <logger name="org.springframework" level="WARN"/>
+  <logger name="org.springframework.web.servlet.DispatcherServlet" level="WARN"/>
+  <logger name="org.hibernate" level="WARN"/>
+  <logger name="org.springdoc" level="WARN"/>
+  <logger name="org.apache.catalina" level="WARN"/>
+  <logger name="org.springframework.boot.autoconfigure.logging" level="OFF"/>
+
+  <!-- suh-logger 라이브러리 -->
+  <logger name="me.suhsaechan.suh-logger" level="DEBUG"/>
+  <logger name="me.suhsaechan.suh-api-log" level="DEBUG"/>
+
+  <!-- 애플리케이션 로그 -->
+  <logger name="com.romrom" level="DEBUG"/>
+
+  <!-- Root 로거 -->
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+    <appender-ref ref="SSE_LOG"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
- #607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 신규 기능
* 실시간 디버그 로그 스트리밍 기능 추가
  * 라이브 로그 스트리밍 제공 (최대 10개 동시 연결)
  * 초당 100개 이벤트 속도 제한
  * 5분 자동 타임아웃
  * 로그 파일 일일 롤오버 및 자동 압축

<!-- end of auto-generated comment: release notes by coderabbit.ai -->