### PR TITLE
채팅_알림_히스토리_미저장_및_isChatNotificationAgreed_푸시알림_설정으로_명세 : feat : 채팅알림 …

### DIFF
--- a/RomRom-Domain-Notification/src/main/java/com/romrom/notification/service/NotificationService.java
+++ b/RomRom-Domain-Notification/src/main/java/com/romrom/notification/service/NotificationService.java
@@ -34,20 +34,23 @@ public class NotificationService {
     LocalDateTime publishedAt = LocalDateTime.parse(payload.get("publishedAt"));
     Member member = memberService.findMemberById(memberId);
 
-    try {
-      notificationHistoryService.saveNotificationHistory(
-        NotificationHistoryRequest.builder()
-          .member(member)
-          .notificationType(notificationType)
-          .title(title)
-          .body(body)
-          .payload(payload)
-          .publishedAt(publishedAt)
-          .build()
-      );
-    } catch (Exception e) {
-      log.error("알림 히스토리 저장 실패: memberId={}, title={}", memberId, title, e);
-      // 히스토리 저장 실패 시에도 FCM 알림 발송 진행
+    // 채팅 알림은 히스토리에 저장하지 않음
+    if (notificationType != NotificationType.CHAT_MESSAGE_RECEIVED) {
+      try {
+        notificationHistoryService.saveNotificationHistory(
+          NotificationHistoryRequest.builder()
+            .member(member)
+            .notificationType(notificationType)
+            .title(title)
+            .body(body)
+            .payload(payload)
+            .publishedAt(publishedAt)
+            .build()
+        );
+      } catch (Exception e) {
+        log.error("알림 히스토리 저장 실패: memberId={}, title={}", memberId, title, e);
+        // 히스토리 저장 실패 시에도 FCM 알림 발송 진행
+      }
     }
 
     // 푸시 알림 설정 체크: 해당 카테고리의 알림이 비활성화 상태면 FCM 발송 스킵


### PR DESCRIPTION
…알림 히스토리 저장 제거 https://github.com/TEAM-ROMROM/RomRom-BE/issues/611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채팅 메시지 수신 알림의 알림 기록 저장이 제거되었습니다. 이를 통해 불필요한 데이터베이스 저장 작업을 줄이고 시스템 성능을 향상시킵니다. 다른 모든 알림 유형들은 기존대로 알림 기록이 저장되고 관리되며, 푸시 발송 기능에는 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->