### PR TITLE
20260412 #638 카카오톡 공유용 물품 정보 조회 공개 api

### DIFF
--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/SecurityUrls.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/SecurityUrls.java
@@ -20,6 +20,9 @@ public class SecurityUrls {
     "/api/auth/login",   // Firebase 통합 로그인
     "/api/auth/reissue", // accessToken 재발급
 
+    // public item - 카카오톡 공유 OG 태그 렌더링용 (Cloud Function 경유 호출)
+    "/api/item/public/get",
+
     // test-api
     "/api/test/sign-up", // 테스트 회원가입
     "/api/test/send/notification/all", // 테스트 전체 알람 발송

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
@@ -392,6 +392,40 @@ public class ItemService {
   }
 
   /**
+   * 공개 물품 상세 조회 (인증 불필요)
+   * - 카카오톡 공유 링크 OG 태그 렌더링을 위한 Cloud Function 호출용
+   * - 좋아요/차단/신고/조회 기록 로직 없음
+   * - 탈퇴/정지 사용자의 물품, 삭제된 물품은 접근 차단
+   */
+  @Transactional(readOnly = true)
+  public ItemResponse getPublicItemDetail(UUID itemId) {
+    Item item = findItemById(itemId);
+    Member itemOwner = item.getMember();
+
+    // 탈퇴한 사용자 물품 조회 차단
+    if (itemOwner.getAccountStatus() == AccountStatus.DELETE_ACCOUNT) {
+      log.debug("탈퇴한 사용자의 공개 물품 조회 시도 차단: memberId={}", itemOwner.getMemberId());
+      throw new CustomException(ErrorCode.DELETED_MEMBER);
+    }
+
+    // 정지된 사용자 물품 조회 차단
+    if (itemOwner.getAccountStatus() == AccountStatus.SUSPENDED_ACCOUNT) {
+      log.debug("정지된 사용자의 공개 물품 조회 시도 차단: memberId={}", itemOwner.getMemberId());
+      throw new CustomException(ErrorCode.SUSPENDED_MEMBER);
+    }
+
+    // 삭제된 물품 조회 차단
+    if (item.getIsDeleted()) {
+      log.debug("삭제된 물품 공개 조회 시도 차단: itemId={}", item.getItemId());
+      throw new CustomException(ErrorCode.DELETED_ITEM);
+    }
+
+    return ItemResponse.builder()
+        .item(item)
+        .build();
+  }
+
+  /**
    * 물품 좋아요 & 취소
    *
    * @param request UUID itemId

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemController.java
@@ -16,9 +16,11 @@ import me.suhsaechan.suhlogger.annotation.LogMonitor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -62,6 +64,14 @@ public class ItemController implements ItemControllerDocs {
     }
 
     return ResponseEntity.ok(response);
+  }
+
+  @Override
+  @GetMapping(value = "/public/get")
+  @LogMonitor
+  public ResponseEntity<ItemResponse> getPublicItemDetail(
+      @RequestParam("itemId") UUID itemId) {
+    return ResponseEntity.ok(itemService.getPublicItemDetail(itemId));
   }
 
   @Override

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemControllerDocs.java
@@ -5,6 +5,7 @@ import com.romrom.common.dto.Author;
 import com.romrom.item.dto.ItemRequest;
 import com.romrom.item.dto.ItemResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import java.util.UUID;
 import me.suhsaechan.suhapilog.annotation.ApiChangeLog;
 import me.suhsaechan.suhapilog.annotation.ApiChangeLogs;
 import org.springframework.http.ResponseEntity;
@@ -464,6 +465,38 @@ public interface ItemControllerDocs {
       CustomUserDetails customUserDetails,
       ItemRequest request
   );
+
+  @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.04.12", author = Author.BAEKJIHOON, issueNumber = 638, description = "카카오톡 공유 OG 태그 렌더링용 공개 물품 상세 조회 API 추가"),
+  })
+  @Operation(
+      summary = "물품 상세 조회 (공개, 인증 불필요)",
+      description = """
+          ## 인증(JWT): **불필요**
+
+          ## 용도
+          - 카카오톡 공유 링크의 OG 태그(썸네일, 제목, 설명) 렌더링을 위한 공개 엔드포인트
+          - 호출 흐름: 카카오톡 크롤러 → Firebase Hosting → Cloud Function rewrite → 본 API 호출 → OG 태그 포함 HTML 응답
+
+          ## 요청 방식
+          - **HTTP Method**: `GET`
+          - **Content-Type**: 없음 (쿼리 파라미터 기반)
+
+          ## 요청 파라미터
+          - **`itemId (UUID)`**: 물품 ID (쿼리 파라미터)
+
+          ## 반환값 (ItemResponse)
+          - **`item`**: 물품 정보 (ItemImage, Member 포함)
+          - 로그인 컨텍스트가 없으므로 `isLiked`, `isBlocked`, `isReported` 필드는 세팅되지 않음
+
+          ## 에러 응답
+          - **ITEM_NOT_FOUND**: 존재하지 않는 물품
+          - **DELETED_ITEM**: 이미 삭제된 물품
+          - **DELETED_MEMBER**: 탈퇴한 사용자의 물품
+          - **SUSPENDED_MEMBER**: 정지된 사용자의 물품
+          """
+  )
+  ResponseEntity<ItemResponse> getPublicItemDetail(UUID itemId);
 
   @ApiChangeLogs({
       @ApiChangeLog(date = "2025.06.27", author = Author.KIMNAYOUNG, issueNumber = 155, description = "물품 가격 예측"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 인증 없이 항목의 공개 상세 정보를 조회할 수 있는 새로운 공개 API 엔드포인트를 추가했습니다. KakaoTalk 미리보기 및 공개 공유 기능을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->