### PR TITLE
선호_카테고리_저장_시_duplicate_key_오류_발생 : feat : 삭제 시 db 즉시 반영으로 변경 https://…

### DIFF
--- a/RomRom-Domain-Member/src/main/java/com/romrom/member/repository/MemberItemCategoryRepository.java
+++ b/RomRom-Domain-Member/src/main/java/com/romrom/member/repository/MemberItemCategoryRepository.java
@@ -4,10 +4,14 @@ import com.romrom.member.entity.MemberItemCategory;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberItemCategoryRepository extends JpaRepository<MemberItemCategory, UUID> {
 
   List<MemberItemCategory> findByMemberMemberId(UUID memberId);
 
+  @Modifying
+  @Query("DELETE FROM MemberItemCategory m WHERE m.member.memberId = :memberId")
   void deleteByMemberMemberId(UUID memberId);
 }


### PR DESCRIPTION
…github.com/TEAM-ROMROM/RomRom-BE/issues/643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 회원 삭제 시 관련된 카테고리 데이터를 효율적으로 정리할 수 있는 기능을 추가하여 데이터 무결성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->