### PR TITLE
선호_카테고리_저장_시_duplicate_key_오류_발생 : feat : 선호 카테고리 임베딩 삭제 후 재저장 https:…

### DIFF
--- a/RomRom-Domain-AI/src/main/java/com/romrom/ai/service/EmbeddingService.java
+++ b/RomRom-Domain-AI/src/main/java/com/romrom/ai/service/EmbeddingService.java
@@ -118,6 +118,7 @@ public class EmbeddingService {
           .originalType(OriginalType.CATEGORY)
           .build();
 
+      embeddingRepository.deleteByOriginalIdAndOriginalType(memberId, OriginalType.CATEGORY);
       embeddingRepository.save(embedding);
       log.debug("회원 선호 카테고리 임베딩 저장 완료: memberId={}", memberId);
 


### PR DESCRIPTION
…//github.com/TEAM-ROMROM/RomRom-BE/issues/643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **버그 수정**
  * 카테고리 임베딩 데이터의 일관성이 개선되었습니다. 새로운 임베딩을 저장할 때 기존 데이터를 먼저 정리하여 중복 항목 생성을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->