### PR TITLE
20260416 #650 물품 id별 채팅방 목록 조회 api 추가

### DIFF
--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/dto/ChatRoomRequest.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/dto/ChatRoomRequest.java
@@ -43,6 +43,9 @@ public class ChatRoomRequest {
   @Schema(description = "거래 요청 ID", example = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
   private UUID tradeRequestHistoryId;
 
+  @Schema(description = "물품 ID (물품별 채팅방 조회 시 사용)", example = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+  private UUID itemId;
+
   @Schema(description = "페이지 번호", defaultValue = "0", example = "0")
   private int pageNumber;
 

--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/repository/postgres/ChatRoomRepository.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/repository/postgres/ChatRoomRepository.java
@@ -32,6 +32,20 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID> {
       countQuery = "SELECT count(c) FROM ChatRoom c WHERE c.tradeReceiver = :tradeReceiver OR c.tradeSender = :tradeSender")
   Page<ChatRoom> findByTradeReceiverOrTradeSender(Member tradeReceiver, Member tradeSender, Pageable pageable);
 
+  // 특정 물품이 포함된 채팅방 조회 (본인이 참여한 채팅방만)
+  @Query(value = "SELECT c FROM ChatRoom c " +
+      "JOIN FETCH c.tradeReceiver JOIN FETCH c.tradeSender " +
+      "JOIN FETCH c.tradeRequestHistory trh " +
+      "JOIN FETCH trh.takeItem " +
+      "JOIN FETCH trh.giveItem " +
+      "WHERE (c.tradeReceiver = :member OR c.tradeSender = :member) " +
+      "AND (trh.takeItem.itemId = :itemId OR trh.giveItem.itemId = :itemId)",
+      countQuery = "SELECT count(c) FROM ChatRoom c " +
+          "JOIN c.tradeRequestHistory trh " +
+          "WHERE (c.tradeReceiver = :member OR c.tradeSender = :member) " +
+          "AND (trh.takeItem.itemId = :itemId OR trh.giveItem.itemId = :itemId)")
+  Page<ChatRoom> findByMemberAndItemId(@Param("member") Member member, @Param("itemId") UUID itemId, Pageable pageable);
+
   @Query("SELECT c.chatRoomId FROM ChatRoom c WHERE c.tradeReceiver.memberId = :id OR c.tradeSender.memberId = :id")
   List<UUID> findAllIdsByMemberId(@Param("id") UUID memberId);
 

--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatRoomService.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatRoomService.java
@@ -135,50 +135,30 @@ public class ChatRoomService {
     // tradeSender, tradeReceiver 모두 페치 조인으로 함께 조회
     // chatroomdetails DTO 에 보낸요청, 받은 요청 필드 추가
     Slice<ChatRoom> chatRoomsSlice = chatRoomRepository.findByTradeReceiverOrTradeSender(member, member, pageable);
-    List<ChatRoom> chatRoomList = chatRoomsSlice.getContent();
-    log.debug("채팅방 목록 조회 완료. 현재 페이지 데이터: {}개.", chatRoomList.size());
+    log.debug("채팅방 목록 조회 완료. 현재 페이지 데이터: {}개.", chatRoomsSlice.getContent().size());
 
-    if (chatRoomList.isEmpty()) {
-      return ChatRoomResponse.builder()
-          .chatRoomDetailDtoPage(Page.empty(pageable))
-          .build();
-    }
-
-    // 조립을 위한 벌크 데이터 준비
-    List<UUID> chatRoomIds = chatRoomList.stream().map(ChatRoom::getChatRoomId).collect(Collectors.toList());
-    long expectedStateCount = (long) chatRoomIds.size() * 2;
-    long actualStateCount = chatUserStateRepository.countByChatRoomIdIn(chatRoomIds);
-    if (actualStateCount != expectedStateCount) {
-      log.warn("ChatUserState 개수가 예상과 달라 자동 복구를 시도합니다. expected={}, actual={}, roomCount={}",
-          expectedStateCount, actualStateCount, chatRoomIds.size());
-      chatUserStateEnsureService.ensureStates(chatRoomList);
-    }
-
-    Map<UUID, Long> unreadCounts = getUnreadCountsByNPlusOneQuery(myMemberId, chatRoomIds);
-    log.debug("안 읽은 메시지 수 조회 완료. 총 {}개 방.", unreadCounts.size());
-
-    Map<UUID, ChatMessage> latestMessageMap = fetchLatestMessageMap(chatRoomIds);
-    Set<UUID> targetMemberIds = fetchTargetMemberIds(chatRoomList, myMemberId);
-    Map<UUID, MemberLocation> locationMap = fetchLocationMap(targetMemberIds);
-    Set<UUID> blockedMemberIds = fetchBlockedMemberIds(myMemberId, targetMemberIds);
-    Map<UUID, String> itemImageMap = fetchItemImageMap(chatRoomList);
-
-    // 필터링 및 DTO 조립
-    List<ChatRoomDetailDto> detailDtoList = chatRoomList.stream()
-        .filter(chatRoom -> {
-          Long count = unreadCounts.get(chatRoom.getChatRoomId());
-          return count != null && count != -1L; // 삭제된 방(-1L) 필터링
-        })
-        .map(chatRoom -> convertToDetailDto(chatRoom, myMemberId, unreadCounts, latestMessageMap, locationMap, blockedMemberIds, itemImageMap))
-        .collect(Collectors.toList());
-
-    Slice<ChatRoomDetailDto> detailSlice = new SliceImpl<>(detailDtoList, pageable, chatRoomsSlice.hasNext());
-
-    return ChatRoomResponse.builder()
-        .chatRoomDetailDtoPage(detailSlice)
-        .build();
+    return buildChatRoomDetailResponse(chatRoomsSlice, myMemberId, pageable);
   }
 
+  // 물품 ID 기반 채팅방 목록 조회
+  @Transactional
+  public ChatRoomResponse getRoomsByItemId(ChatRoomRequest request) {
+    Member member = request.getMember();
+    UUID myMemberId = member.getMemberId();
+    UUID itemId = request.getItemId();
+    log.debug("물품별 채팅방 목록 조회 시작. 요청자 ID: {}, 물품 ID: {}", myMemberId, itemId);
+
+    Pageable pageable = PageRequest.of(
+        request.getPageNumber(),
+        request.getPageSize(),
+        Sort.by(Sort.Direction.DESC, "createdDate")
+    );
+
+    Slice<ChatRoom> chatRoomsSlice = chatRoomRepository.findByMemberAndItemId(member, itemId, pageable);
+    log.debug("물품별 채팅방 목록 조회 완료. 현재 페이지 데이터: {}개.", chatRoomsSlice.getContent().size());
+
+    return buildChatRoomDetailResponse(chatRoomsSlice, myMemberId, pageable);
+  }
 
   // 채팅방 삭제
   @Transactional
@@ -242,6 +222,54 @@ public class ChatRoomService {
   }
 
   // --- Private Helper Methods ---
+
+  /**
+   * ChatRoom 슬라이스로부터 벌크 데이터를 조회하고, 삭제/나간 채팅방을 필터링한 뒤
+   * ChatRoomDetailDto 목록을 조립하여 ChatRoomResponse를 반환하는 공통 로직
+   */
+  private ChatRoomResponse buildChatRoomDetailResponse(Slice<ChatRoom> chatRoomsSlice, UUID myMemberId, Pageable pageable) {
+    List<ChatRoom> chatRoomList = chatRoomsSlice.getContent();
+
+    if (chatRoomList.isEmpty()) {
+      return ChatRoomResponse.builder()
+          .chatRoomDetailDtoPage(Page.empty(pageable))
+          .build();
+    }
+
+    // 조립을 위한 벌크 데이터 준비
+    List<UUID> chatRoomIds = chatRoomList.stream().map(ChatRoom::getChatRoomId).collect(Collectors.toList());
+    long expectedStateCount = (long) chatRoomIds.size() * 2;
+    long actualStateCount = chatUserStateRepository.countByChatRoomIdIn(chatRoomIds);
+    if (actualStateCount != expectedStateCount) {
+      log.warn("ChatUserState 개수가 예상과 달라 자동 복구를 시도합니다. expected={}, actual={}, roomCount={}",
+          expectedStateCount, actualStateCount, chatRoomIds.size());
+      chatUserStateEnsureService.ensureStates(chatRoomList);
+    }
+
+    Map<UUID, Long> unreadCounts = getUnreadCountsByNPlusOneQuery(myMemberId, chatRoomIds);
+    log.debug("안 읽은 메시지 수 조회 완료. 총 {}개 방.", unreadCounts.size());
+
+    Map<UUID, ChatMessage> latestMessageMap = fetchLatestMessageMap(chatRoomIds);
+    Set<UUID> targetMemberIds = fetchTargetMemberIds(chatRoomList, myMemberId);
+    Map<UUID, MemberLocation> locationMap = fetchLocationMap(targetMemberIds);
+    Set<UUID> blockedMemberIds = fetchBlockedMemberIds(myMemberId, targetMemberIds);
+    Map<UUID, String> itemImageMap = fetchItemImageMap(chatRoomList);
+
+    // 삭제/나간 채팅방 필터링 및 DTO 조립
+    List<ChatRoomDetailDto> detailDtoList = chatRoomList.stream()
+        .filter(chatRoom -> {
+          Long count = unreadCounts.get(chatRoom.getChatRoomId());
+          return count != null && count != -1L; // 삭제된 방(-1L) 필터링
+        })
+        .map(chatRoom -> convertToDetailDto(chatRoom, myMemberId, unreadCounts, latestMessageMap, locationMap, blockedMemberIds, itemImageMap))
+        .collect(Collectors.toList());
+
+    Slice<ChatRoomDetailDto> detailSlice = new SliceImpl<>(detailDtoList, pageable, chatRoomsSlice.hasNext());
+
+    return ChatRoomResponse.builder()
+        .chatRoomDetailDtoPage(detailSlice)
+        .build();
+  }
 
   /**
    * [공통 로직] 채팅방 나가기 프로세스

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatController.java
@@ -61,6 +61,19 @@ public class ChatController implements ChatControllerDocs {
   }
 
   /**
+   * 물품 ID별 채팅방 목록 조회
+   */
+  @Override
+  @PostMapping(value = "/get/item", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @LogMonitor
+  public ResponseEntity<ChatRoomResponse> getRoomsByItemId(
+      @ModelAttribute ChatRoomRequest request,
+      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    request.setMember(customUserDetails.getMember());
+    return ResponseEntity.ok(chatRoomService.getRoomsByItemId(request));
+  }
+
+  /**
    * 방 삭제 (본인 포함된 방만 가능)
    */
   @Override

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatControllerDocs.java
@@ -54,6 +54,41 @@ public interface ChatControllerDocs {
   ResponseEntity<ChatRoomResponse> getRooms(ChatRoomRequest request, CustomUserDetails customUserDetails);
 
   @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.04.17", author = Author.BAEKJIHOON, issueNumber = 650, description = "물품 ID 기반 채팅방 목록 조회 API 추가")
+  })
+  @Operation(
+      summary = "물품별 채팅방 목록 조회",
+      description = """
+    ### 인증(JWT): **필수**
+
+    ### 요청 파라미터 (ChatRoomRequest)
+    - `itemId` (UUID) : 조회할 물품 ID (**필수**)
+    - `pageNumber` : 페이지 번호 (기본 0)
+    - `pageSize` : 페이지 크기 (기본 30)
+
+    ### 동작
+    - 로그인한 사용자가 속한 채팅방 중, 해당 물품(takeItem 또는 giveItem)이 포함된 채팅방 목록을 페이징으로 반환합니다.
+    - 최신 생성일(createdDate) 순으로 정렬됩니다.
+    - 본인이 나간(삭제한) 채팅방은 목록에 포함되지 않습니다.
+
+    ### 반환값 (ChatRoomResponse)
+    - `chatRoomDetailDtoPage` (Slice<ChatRoomDetailDto>): 해당 물품이 포함된 채팅방 목록과 각 방의 세부 정보
+    아래는 ChatRoomDetailDto 정보입니다.
+    - `chatRoomId` (UUID) : 채팅방 ID
+    - `blocked` (boolean) : 차단 여부 (내가 상대방을 차단했거나 상대방이 나를 차단한 경우 true)
+    - `targetMember` (Member) : 상대방 정보 (isOnline, lastActiveAt 포함)
+    - `targetMemberEupMyeonDong` (String) : 상대방 위치 (읍면동)
+    - `lastMessageContent` (String) : 마지막 메시지 내용
+    - `lastMessageTime` (LocalDateTime) : 마지막 메시지가 생성된 시간
+    - `unreadCount` (Long) : 안 읽은 메시지 개수
+    - `chatRoomType` (ENUM) : 받은 요청, 보낸 요청 여부 (RECEIVED, REQUESTED)
+    - `targetItemImageUrl` (String, nullable) : 상대방 물품의 대표 이미지 URL (이미지 미등록 시 null)
+    - `myItemImageUrl` (String, nullable) : 내 교환 물품의 대표 이미지 URL (이미지 미등록 시 null)
+    """
+  )
+  ResponseEntity<ChatRoomResponse> getRoomsByItemId(ChatRoomRequest request, CustomUserDetails customUserDetails);
+
+  @ApiChangeLogs({
       @ApiChangeLog(date = "2026.02.01", author = Author.WISEUNGJAE, issueNumber = 467, description = "생성 시 대기중인 요청만 채팅방 생성 가능하도록 수정"),
       @ApiChangeLog(date = "2026.01.03", author = Author.WISEUNGJAE, issueNumber = 428, description = "차단된 회원과의 채팅방 생성을 방지하는 검증 로직 추가"),
       @ApiChangeLog(date = "2025.11.04", author = Author.WISEUNGJAE, issueNumber = 318, description = "채팅방 중복 생성 방지 기능 추가"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 물품별 채팅방 조회 기능이 추가되었습니다. 특정 물품과 관련된 채팅방을 생성일순(최신순)으로 조회할 수 있으며, 사용자가 나간 채팅방은 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->