### PR TITLE
SSE 서버 로그 스트리밍 연결 즉시 종료 및 구독자 누적 문제

### DIFF
--- a/RomRom-Common/src/main/java/com/romrom/common/logging/SseLogAppender.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/logging/SseLogAppender.java
@@ -17,6 +17,10 @@ public class SseLogAppender extends AppenderBase<ILoggingEvent> {
 
   private static final String TARGET_LOGGER_PREFIX = "com.romrom";
 
+  // SSE 내부 클래스 로그는 FE에 전송하지 않음 (피드백 루프 방지)
+  private static final String SSE_BROADCASTER_LOGGER = "com.romrom.common.service.SseLogBroadcaster";
+  private static final String SSE_CONTROLLER_LOGGER = "com.romrom.web.controller.api.DebugController";
+
   private static volatile ApplicationContext applicationContext;
   private volatile SseLogBroadcaster sseLogBroadcaster;
 
@@ -30,7 +34,13 @@ public class SseLogAppender extends AppenderBase<ILoggingEvent> {
   @Override
   protected void append(ILoggingEvent loggingEvent) {
     // com.romrom 패키지 로그만 처리
-    if (!loggingEvent.getLoggerName().startsWith(TARGET_LOGGER_PREFIX)) {
+    String loggerName = loggingEvent.getLoggerName();
+    if (!loggerName.startsWith(TARGET_LOGGER_PREFIX)) {
+      return;
+    }
+
+    // SSE 내부 클래스 로그는 제외 (FE 피드백 루프 방지)
+    if (loggerName.equals(SSE_BROADCASTER_LOGGER) || loggerName.equals(SSE_CONTROLLER_LOGGER)) {
       return;
     }
 

--- a/RomRom-Common/src/main/java/com/romrom/common/service/SseLogBroadcaster.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/service/SseLogBroadcaster.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -17,7 +16,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
  * - 초당 로그 이벤트 제한: 100건
  */
 @Component
-@Slf4j
 public class SseLogBroadcaster {
 
   private static final int MAX_SUBSCRIBERS = 10;
@@ -41,11 +39,9 @@ public class SseLogBroadcaster {
    */
   public boolean addSubscriber(SseEmitter sseLogEmitter) {
     if (debugLogSubscribers.size() >= MAX_SUBSCRIBERS) {
-      log.warn("SSE 로그 스트리밍 최대 구독자 수 초과: {}/{}", debugLogSubscribers.size(), MAX_SUBSCRIBERS);
       return false;
     }
     debugLogSubscribers.add(sseLogEmitter);
-    log.info("SSE 로그 스트리밍 구독자 등록 (현재: {}명)", debugLogSubscribers.size());
     return true;
   }
 
@@ -54,7 +50,6 @@ public class SseLogBroadcaster {
    */
   public void removeSubscriber(SseEmitter sseLogEmitter) {
     debugLogSubscribers.remove(sseLogEmitter);
-    log.info("SSE 로그 스트리밍 구독자 제거 (현재: {}명)", debugLogSubscribers.size());
   }
 
   /**

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugController.java
@@ -3,8 +3,12 @@ package com.romrom.web.controller.api;
 import com.romrom.common.annotation.SecuredApi;
 import com.romrom.common.service.SseLogBroadcaster;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,10 +25,17 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 @Tag(name = "디버그 API", description = "테스트 빌드용 디버그 도구 API")
 @RequestMapping("/api/app")
-@Slf4j
 public class DebugController implements DebugControllerDocs {
 
   private static final long SSE_LOG_STREAM_TIMEOUT = 300_000L; // 5분
+  private static final long SSE_HEARTBEAT_INTERVAL_SECONDS = 30L;
+
+  private static final ScheduledExecutorService heartbeatScheduler =
+      Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread heartbeatThread = new Thread(r, "sse-heartbeat");
+        heartbeatThread.setDaemon(true);
+        return heartbeatThread;
+      });
 
   private final SseLogBroadcaster sseLogBroadcaster;
 
@@ -39,21 +50,37 @@ public class DebugController implements DebugControllerDocs {
       throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "최대 동시 접속 수 초과");
     }
 
-    // 연결 종료 시 구독자 제거 (onTimeout/onError → complete() → onCompletion 순서로 호출됨)
-    debugLogEmitter.onCompletion(() -> {
+    // 연결 수립 즉시 connected 이벤트 전송 — iOS URLSession이 빈 body로 판단해 끊는 것 방지
+    try {
+      debugLogEmitter.send(SseEmitter.event().name("connected").data("connected"));
+    } catch (IOException e) {
       sseLogBroadcaster.removeSubscriber(debugLogEmitter);
-      log.debug("SSE 로그 스트리밍 연결 종료");
+      return debugLogEmitter;
+    }
+
+    // 30초마다 heartbeat comment 전송 — idle timeout 방지
+    ScheduledFuture<?> heartbeatTask = heartbeatScheduler.scheduleAtFixedRate(() -> {
+      try {
+        debugLogEmitter.send(SseEmitter.event().comment("heartbeat"));
+      } catch (IOException e) {
+        sseLogBroadcaster.removeSubscriber(debugLogEmitter);
+      }
+    }, SSE_HEARTBEAT_INTERVAL_SECONDS, SSE_HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
+
+    debugLogEmitter.onCompletion(() -> {
+      heartbeatTask.cancel(false);
+      sseLogBroadcaster.removeSubscriber(debugLogEmitter);
     });
     debugLogEmitter.onTimeout(() -> {
-      log.debug("SSE 로그 스트리밍 타임아웃 (5분)");
+      heartbeatTask.cancel(false);
+      sseLogBroadcaster.removeSubscriber(debugLogEmitter);
       debugLogEmitter.complete();
     });
     debugLogEmitter.onError(throwable -> {
-      log.debug("SSE 로그 스트리밍 에러: {}", throwable.getMessage());
+      heartbeatTask.cancel(false);
+      sseLogBroadcaster.removeSubscriber(debugLogEmitter);
       debugLogEmitter.complete();
     });
-
-    log.info("SSE 로그 스트리밍 연결 수립 (활성 구독자: {}명)", sseLogBroadcaster.getActiveSubscriberCount());
 
     return debugLogEmitter;
   }

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugController.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -55,17 +56,25 @@ public class DebugController implements DebugControllerDocs {
       debugLogEmitter.send(SseEmitter.event().name("connected").data("connected"));
     } catch (IOException e) {
       sseLogBroadcaster.removeSubscriber(debugLogEmitter);
+      debugLogEmitter.complete();
       return debugLogEmitter;
     }
 
     // 30초마다 heartbeat comment 전송 — idle timeout 방지
+    // AtomicReference: 람다 내부에서 heartbeatTask 자기 자신을 참조하기 위한 전방 참조 처리
+    AtomicReference<ScheduledFuture<?>> heartbeatTaskRef = new AtomicReference<>();
     ScheduledFuture<?> heartbeatTask = heartbeatScheduler.scheduleAtFixedRate(() -> {
       try {
         debugLogEmitter.send(SseEmitter.event().comment("heartbeat"));
       } catch (IOException e) {
+        ScheduledFuture<?> selfHeartbeatTask = heartbeatTaskRef.get();
+        if (selfHeartbeatTask != null) {
+          selfHeartbeatTask.cancel(false);
+        }
         sseLogBroadcaster.removeSubscriber(debugLogEmitter);
       }
     }, SSE_HEARTBEAT_INTERVAL_SECONDS, SSE_HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    heartbeatTaskRef.set(heartbeatTask);
 
     debugLogEmitter.onCompletion(() -> {
       heartbeatTask.cancel(false);


### PR DESCRIPTION
- https://github.com/TEAM-ROMROM/RomRom-BE/issues/656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSE 실시간 로그 스트림 연결 안정성 개선, 30초 주기의 heartbeat 신호 추가로 연결 끊김 방지

* **Chores**
  * 내부 로거의 불필요한 로그 메시지 제거 및 로그 필터링 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->