### PR TITLE
관리자 삭제 물품에 대한 채팅방 UX 및 알림 고도화

### DIFF
--- a/RomRom-Application/src/main/java/com/romrom/application/dto/AdminRequest.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/dto/AdminRequest.java
@@ -1,6 +1,7 @@
 package com.romrom.application.dto;
 
 import com.romrom.common.constant.AccountStatus;
+import com.romrom.common.constant.ItemAdminDeleteReason;
 import com.romrom.common.constant.ItemCategory;
 import com.romrom.common.constant.ItemCondition;
 import com.romrom.common.constant.ItemStatus;
@@ -50,6 +51,12 @@ public class AdminRequest {
     // 물품 관련 필드
     @Schema(description = "물품 ID (삭제, 상세 조회 시 사용)")
     private UUID itemId;
+
+    @Schema(description = "관리자 삭제 사유 카테고리 (물품 삭제 시 필수)")
+    private ItemAdminDeleteReason itemAdminDeleteReason;
+
+    @Schema(description = "관리자 삭제 상세 사유 (물품 삭제 시 선택, 내부용)")
+    private String itemAdminDeleteDetail;
 
     @Schema(description = "검색 키워드 (물품명, 설명, 판매자 닉네임, 회원 닉네임)")
     private String searchKeyword;

--- a/RomRom-Common/src/main/java/com/romrom/common/constant/ItemAdminDeleteReason.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/constant/ItemAdminDeleteReason.java
@@ -1,0 +1,18 @@
+package com.romrom.common.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ItemAdminDeleteReason {
+  PROHIBITED_ITEM(1, "거래 금지 품목"),
+  FRAUD_SUSPECTED(2, "사기 의심"),
+  INAPPROPRIATE_CONTENT(3, "부적절한 콘텐츠"),
+  COPYRIGHT_VIOLATION(4, "저작권 침해"),
+  REPORT_ACCUMULATED(5, "신고 누적"),
+  ETC(6, "기타");
+
+  private final int code;
+  private final String description;
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
@@ -150,6 +150,8 @@ public enum ErrorCode {
 
   CANNOT_SEND_MESSAGE_TO_DELETED_CHATROOM(HttpStatus.FORBIDDEN, "거래요청이 취소되었거나 거래완료된 상태이므로, 메시지를 보낼 수 없습니다."),
 
+  CANNOT_SEND_MESSAGE_TO_ADMIN_DELETED_ITEM_CHATROOM(HttpStatus.FORBIDDEN, "삭제된 물품이라 더 이상 대화할 수 없습니다."),
+
   CHAT_USER_STATE_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 상태를 찾을 수 없습니다."),
 
   CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),

--- a/RomRom-Common/src/main/java/com/romrom/common/service/SseLogBroadcaster.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/service/SseLogBroadcaster.java
@@ -90,7 +90,9 @@ public class SseLogBroadcaster {
       try {
         subscriberEmitter.send(SseEmitter.event().data(debugLogJson));
       } catch (IOException e) {
+        // completeWithError → onError 콜백 → removeSubscriber 호출로 cleanup 일원화
         debugLogSubscribers.remove(subscriberEmitter);
+        subscriberEmitter.completeWithError(e);
       }
     }
   }
@@ -105,6 +107,7 @@ public class SseLogBroadcaster {
         subscriberEmitter.send(SseEmitter.event().data(skippedMessage));
       } catch (IOException e) {
         debugLogSubscribers.remove(subscriberEmitter);
+        subscriberEmitter.completeWithError(e);
       }
     }
   }

--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatMessageService.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatMessageService.java
@@ -9,6 +9,7 @@ import com.romrom.chat.entity.mongo.ChatMessage;
 import com.romrom.chat.entity.mongo.ChatUserState;
 import com.romrom.chat.entity.mongo.MessageType;
 import com.romrom.chat.entity.postgres.ChatRoom;
+import com.romrom.item.entity.postgres.TradeRequestHistory;
 import com.romrom.chat.repository.mongo.ChatMessageRepository;
 import com.romrom.chat.repository.mongo.ChatUserStateRepository;
 import com.romrom.chat.repository.postgres.ChatRoomRepository;
@@ -112,6 +113,15 @@ public class ChatMessageService {
       log.debug("상대방이 채팅방을 삭제한 상태, 즉 거래요청이 취소/거래완료 상태이므로 메시지 전송 불가. recipientId: {}, chatRoomId: {}", recipientId, chatRoom.getChatRoomId());
       throw new CustomException(ErrorCode.CANNOT_SEND_MESSAGE_TO_DELETED_CHATROOM);
     }
+
+    // 연결된 물품이 관리자에 의해 삭제된 경우 메시지 전송 차단
+    TradeRequestHistory tradeRequestHistory = chatRoom.getTradeRequestHistory();
+    if (Boolean.TRUE.equals(tradeRequestHistory.getGiveItem().getIsDeleted())
+        || Boolean.TRUE.equals(tradeRequestHistory.getTakeItem().getIsDeleted())) {
+      log.debug("관리자에 의해 삭제된 물품 채팅방 메시지 전송 차단. chatRoomId: {}", chatRoom.getChatRoomId());
+      throw new CustomException(ErrorCode.CANNOT_SEND_MESSAGE_TO_ADMIN_DELETED_ITEM_CHATROOM);
+    }
+
     memberBlockService.verifyNotBlocked(senderId, recipientId);
 
     if (request.getType() == null || !request.getType().isClientSendable()) {

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/entity/postgres/Item.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/entity/postgres/Item.java
@@ -3,6 +3,7 @@ package com.romrom.item.entity.postgres;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.romrom.common.constant.ItemAdminDeleteReason;
 import com.romrom.common.constant.ItemCategory;
 import com.romrom.common.constant.ItemCondition;
 import com.romrom.common.constant.ItemStatus;
@@ -100,6 +101,12 @@ public class Item extends BasePostgresEntity {
   @Builder.Default
   @JsonIgnore
   private Boolean isDeleted = false;
+
+  @Enumerated(EnumType.STRING)
+  private ItemAdminDeleteReason adminDeleteReason; // 관리자 삭제 사유 카테고리
+
+  @Column(length = 500)
+  private String adminDeleteDetail; // 관리자 삭제 상세 사유 (내부용, 사용자 비공개)
 
   @Transient
   private Boolean isBlocked; // 현재 사용자와 물품 등록자 간 차단 여부

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
@@ -4,6 +4,7 @@ import com.romrom.ai.service.EmbeddingService;
 import com.romrom.ai.service.VertexAiClient;
 import com.romrom.common.constant.AccountStatus;
 import com.romrom.common.constant.InteractionType;
+import com.romrom.common.constant.ItemAdminDeleteReason;
 import com.romrom.common.constant.ItemCategory;
 import com.romrom.common.constant.ItemSortField;
 import com.romrom.common.constant.ItemStatus;
@@ -713,7 +714,7 @@ public class ItemService {
    * - 영향받는 거래 상대방에게 FCM 알림 발송 (트랜잭션 커밋 후 비동기 처리)
    */
   @Transactional
-  public void deleteItemByAdmin(UUID itemId) {
+  public void deleteItemByAdmin(UUID itemId, ItemAdminDeleteReason adminDeleteReason, String adminDeleteDetail) {
     Item item = itemRepository.findById(itemId)
         .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
 
@@ -728,6 +729,12 @@ public class ItemService {
         .distinct()
         .collect(Collectors.toList());
 
+    // 물품 소유자도 알림 대상에 포함
+    UUID itemOwnerId = item.getMember().getMemberId();
+    if (!affectedMemberIds.contains(itemOwnerId)) {
+      affectedMemberIds.add(itemOwnerId);
+    }
+
     // 2. 관련 TradeRequestHistory CANCELED 처리 (chat_room FK 제약 위반 방지)
     tradeRequestHistoryRepository.cancelAllActiveByItemId(itemId);
 
@@ -740,15 +747,17 @@ public class ItemService {
     // 5. 좋아요 내역 삭제
     likeHistoryRepository.deleteAllByItemId(itemId);
 
-    // 6. Soft Delete (isDeleted = true)
-    itemRepository.deleteByItemId(itemId);
+    // 6. Soft Delete + 삭제 사유 저장
+    item.setIsDeleted(true);
+    item.setAdminDeleteReason(adminDeleteReason);
+    item.setAdminDeleteDetail(adminDeleteDetail);
 
     // 7. 알림 이벤트 발행 (트랜잭션 커밋 후 비동기 처리)
     if (!affectedMemberIds.isEmpty()) {
-      eventPublisher.publishEvent(new ItemDeletedByAdminEvent(affectedMemberIds, item.getItemName()));
+      eventPublisher.publishEvent(new ItemDeletedByAdminEvent(affectedMemberIds, item.getItemName(), adminDeleteReason));
     }
 
-    log.info("관리자 물품 Soft Delete 완료: itemId={}, canceledTradeHistories={}, notifiedMembers={}",
-        itemId, relatedTradeHistories.size(), affectedMemberIds.size());
+    log.info("관리자 물품 Soft Delete 완료: itemId={}, reason={}, canceledTradeHistories={}, notifiedMembers={}",
+        itemId, adminDeleteReason, relatedTradeHistories.size(), affectedMemberIds.size());
   }
 }

--- a/RomRom-Domain-Notification/src/main/java/com/romrom/notification/event/ItemDeletedByAdminEvent.java
+++ b/RomRom-Domain-Notification/src/main/java/com/romrom/notification/event/ItemDeletedByAdminEvent.java
@@ -1,5 +1,6 @@
 package com.romrom.notification.event;
 
+import com.romrom.common.constant.ItemAdminDeleteReason;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,19 +10,20 @@ import lombok.Getter;
 /**
  * 관리자에 의해 물품 삭제 알림 이벤트 (다수 회원 대상)
  * - 기존 NotificationEvent는 단일 targetMemberId 설계이므로 독립 클래스로 생성
- * - Title: 관리자 알림
- * - Body: 관리자에 의해 물품이 삭제되었습니다
+ * - Body: "{물품명}이(가) {삭제사유} 사유로 삭제되었습니다."
  */
 @Getter
 public class ItemDeletedByAdminEvent {
 
   private final List<UUID> affectedMemberIds;
   private final String deletedItemName;
+  private final ItemAdminDeleteReason adminDeleteReason;
   private final Map<String, String> payload;
 
-  public ItemDeletedByAdminEvent(List<UUID> affectedMemberIds, String deletedItemName) {
+  public ItemDeletedByAdminEvent(List<UUID> affectedMemberIds, String deletedItemName, ItemAdminDeleteReason adminDeleteReason) {
     this.affectedMemberIds = affectedMemberIds;
     this.deletedItemName = deletedItemName;
+    this.adminDeleteReason = adminDeleteReason;
     this.payload = new HashMap<>();
     this.payload.put("notificationType", NotificationType.ITEM_DELETED_BY_ADMIN.name());
   }
@@ -31,6 +33,9 @@ public class ItemDeletedByAdminEvent {
   }
 
   public String getBody() {
-    return NotificationType.ITEM_DELETED_BY_ADMIN.getBody();
+    String reasonDescription = adminDeleteReason != null
+        ? adminDeleteReason.getDescription()
+        : ItemAdminDeleteReason.ETC.getDescription();
+    return String.format("회원님의 물품 '%s'이(가) '%s' 사유로 삭제되었습니다.", deletedItemName, reasonDescription);
   }
 }

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AdminApiController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AdminApiController.java
@@ -136,7 +136,7 @@ public class AdminApiController {
     @PostMapping(value = "/items/delete", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @LogMonitor
     public ResponseEntity<Void> deleteItem(@ModelAttribute AdminRequest request) {
-        itemService.deleteItemByAdmin(request.getItemId());
+        itemService.deleteItemByAdmin(request.getItemId(), request.getItemAdminDeleteReason(), request.getItemAdminDeleteDetail());
         return ResponseEntity.ok().build();
     }
 

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/DebugController.java
@@ -29,7 +29,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class DebugController implements DebugControllerDocs {
 
   private static final long SSE_LOG_STREAM_TIMEOUT = 300_000L; // 5분
-  private static final long SSE_HEARTBEAT_INTERVAL_SECONDS = 30L;
+  private static final long SSE_HEARTBEAT_INTERVAL_SECONDS = 10L; // 죽은 연결 감지 주기 (30→10초)
 
   private static final ScheduledExecutorService heartbeatScheduler =
       Executors.newSingleThreadScheduledExecutor(r -> {
@@ -67,11 +67,12 @@ public class DebugController implements DebugControllerDocs {
       try {
         debugLogEmitter.send(SseEmitter.event().comment("heartbeat"));
       } catch (IOException e) {
+        // 클라이언트가 연결을 끊은 것 — completeWithError로 onError 콜백을 통해 cleanup 일원화
         ScheduledFuture<?> selfHeartbeatTask = heartbeatTaskRef.get();
         if (selfHeartbeatTask != null) {
           selfHeartbeatTask.cancel(false);
         }
-        sseLogBroadcaster.removeSubscriber(debugLogEmitter);
+        debugLogEmitter.completeWithError(e);
       }
     }, SSE_HEARTBEAT_INTERVAL_SECONDS, SSE_HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
     heartbeatTaskRef.set(heartbeatTask);
@@ -88,7 +89,6 @@ public class DebugController implements DebugControllerDocs {
     debugLogEmitter.onError(throwable -> {
       heartbeatTask.cancel(false);
       sseLogBroadcaster.removeSubscriber(debugLogEmitter);
-      debugLogEmitter.complete();
     });
 
     return debugLogEmitter;

--- a/RomRom-Web/src/main/resources/db/migration/V1_4_59__add_item_admin_delete_reason_columns.sql
+++ b/RomRom-Web/src/main/resources/db/migration/V1_4_59__add_item_admin_delete_reason_columns.sql
@@ -1,0 +1,22 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'item'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns WHERE table_name = 'item' AND column_name = 'admin_delete_reason'
+    ) THEN
+        ALTER TABLE item ADD COLUMN admin_delete_reason VARCHAR(50);
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'item'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns WHERE table_name = 'item' AND column_name = 'admin_delete_detail'
+    ) THEN
+        ALTER TABLE item ADD COLUMN admin_delete_detail VARCHAR(500);
+    END IF;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING '오류 발생: %', SQLERRM;
+END $$;


### PR DESCRIPTION
## Summary
- `ItemAdminDeleteReason` enum 신규 추가 (거래 금지 품목, 사기 의심, 부적절한 콘텐츠, 저작권 침해, 신고 누적, 기타)
- `Item` 엔티티에 `adminDeleteReason`, `adminDeleteDetail` 필드 추가 및 Flyway 마이그레이션 (`V1_4_59`)
- 관리자 물품 삭제 API에 삭제 사유/상세 사유 파라미터 추가 (`AdminRequest` 확장)
- 알림 본문 동적화: 고정 문구 → '물품명'이(가) '사유' 사유로 삭제되었습니다.
- 채팅 메시지 전송 시 물품 삭제 여부 체크 추가 - 삭제된 물품 채팅방은 전송 차단

## Related Issue
Closes #629

## Test plan
- [ ] 관리자 물품 삭제 API 호출 시 삭제 사유 필수 파라미터 전달 확인
- [ ] 삭제된 물품 채팅방에서 메시지 전송 시 403 응답 확인
- [ ] FCM 알림 본문에 물품명 및 삭제 사유 카테고리 동적 포함 확인
- [ ] Flyway 마이그레이션 정상 적용 확인 (admin_delete_reason, admin_delete_detail 컬럼)

🤖 Generated with [Claude Code](https://claude.com/claude-code)