### PR TITLE
20260420 #654 채팅방 입장시 chat recommendation constants 초기화 실패

### DIFF
--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/constant/ChatRecommendationConstants.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/constant/ChatRecommendationConstants.java
@@ -5,8 +5,7 @@ import kr.suhsaechan.ai.model.JsonSchema;
 public final class ChatRecommendationConstants {
 
   public static final String DEFAULT_CHAT_MODEL = "functiongemma";
-  public static final JsonSchema RESPONSE_SCHEMA = JsonSchema.object("action")
-      .property("action", "string")
+  public static final JsonSchema RESPONSE_SCHEMA = JsonSchema.object("action", "string")
       .required("action");
 
   public static final String CACHE_KEY_PREFIX = "CHAT:RECOMMEND:CACHE:";

--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/listener/ChatWebSocketDisconnectListener.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/listener/ChatWebSocketDisconnectListener.java
@@ -1,0 +1,45 @@
+package com.romrom.chat.listener;
+
+import com.romrom.auth.dto.CustomUserDetails;
+import com.romrom.chat.service.ChatRoomService;
+import com.romrom.chat.stomp.interceptor.CustomChannelInterceptor;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ChatWebSocketDisconnectListener {
+
+  private final ChatRoomService chatRoomService;
+
+  @EventListener
+  public void handle(SessionDisconnectEvent event) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+    Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+    if (sessionAttributes == null) {
+      log.debug("웹소켓 연결 종료 처리 중 세션 속성을 찾을 수 없습니다. sessionId={}", accessor.getSessionId());
+      return;
+    }
+
+    Object sessionUser = sessionAttributes.get(CustomChannelInterceptor.SESSION_USER_KEY);
+    if (!(sessionUser instanceof CustomUserDetails customUserDetails)) {
+      log.debug("웹소켓 연결 종료 처리 중 세션 사용자를 찾을 수 없습니다. sessionId={}", accessor.getSessionId());
+      return;
+    }
+
+    UUID memberId = customUserDetails.getMember().getMemberId();
+    try {
+      chatRoomService.leaveActiveChatRooms(memberId);
+    } catch (Exception e) {
+      log.error("웹소켓 연결 종료 중 active 채팅방 퇴장 처리 실패. memberId={}, error={}",
+          memberId, e.getMessage(), e);
+    }
+  }
+}

--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/repository/mongo/ChatUserStateRepository.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/repository/mongo/ChatUserStateRepository.java
@@ -11,6 +11,7 @@ public interface ChatUserStateRepository extends MongoRepository<ChatUserState, 
     Optional<ChatUserState> findByChatRoomIdAndMemberId(UUID chatRoomId, UUID memberId);
     List<ChatUserState> findByChatRoomIdIn(List<UUID> chatRoomIds);
     long countByChatRoomIdIn(List<UUID> chatRoomIds);
+    List<ChatUserState> findByMemberIdAndLeftAtIsNull(UUID memberId);
     List<ChatUserState> findByMemberIdAndChatRoomIdIn(UUID memberId, List<UUID> chatRoomIds);
     void deleteAllByChatRoomId(UUID chatRoomId);
 

--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatRoomService.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatRoomService.java
@@ -194,19 +194,27 @@ public class ChatRoomService {
     ChatUserState myState = chatUserStateRepository.findByChatRoomIdAndMemberId(room.getChatRoomId(), memberId)
         .orElseThrow(() -> new CustomException(ErrorCode.CHAT_USER_STATE_NOT_FOUND));
 
-    if (request.getIsEntered()) {
+    if (Boolean.TRUE.equals(request.getIsEntered())) {
+      leaveOtherActiveChatRooms(memberId, chatRoomId);
       myState.enterChatRoom();
+      chatUserStateRepository.save(myState);
+      sendReadEventIfOpponentPresent(myState);
     } else {
-      myState.leaveChatRoom();
+      leaveChatRoomPresence(myState);
     }
-    chatUserStateRepository.save(myState);
+  }
 
-    ChatUserState opponentState = chatUserStateRepository.findByChatRoomIdAndMemberIdNot(room.getChatRoomId(), memberId)
-        .orElseThrow(() -> new CustomException(ErrorCode.CHAT_USER_STATE_NOT_FOUND));
-    if(!opponentState.isDeleted() && opponentState.isPresent()) {
-      log.debug("상대방이 현재 화면에 있으므로, 읽음 이벤트를 브로커로 송출합니다. roomId={}, memberId={}", chatRoomId, memberId);
-      chatWebSocketService.sendReadEvent(myState);
+  // 웹소켓 연결이 비정상 종료된 경우에도 현재 열린 채팅방만 퇴장 처리한다.
+  @Transactional
+  public void leaveActiveChatRooms(UUID memberId) {
+    List<ChatUserState> activeStates = chatUserStateRepository.findByMemberIdAndLeftAtIsNull(memberId);
+    if (activeStates.isEmpty()) {
+      return;
     }
+
+    log.debug("웹소켓 연결 종료로 활성 채팅방 퇴장 처리를 시작합니다. memberId={}, activeRoomCount={}",
+        memberId, activeStates.size());
+    activeStates.forEach(this::leaveChatRoomPresence);
   }
 
   @Transactional
@@ -222,6 +230,37 @@ public class ChatRoomService {
   }
 
   // --- Private Helper Methods ---
+
+  // 한 계정이 동시에 여러 방을 보고 있는 상태가 남지 않도록 입장 전에 기존 active 방을 정리한다.
+  private void leaveOtherActiveChatRooms(UUID memberId, UUID currentChatRoomId) {
+    List<ChatUserState> activeStates = chatUserStateRepository.findByMemberIdAndLeftAtIsNull(memberId);
+    activeStates.stream()
+        .filter(state -> !currentChatRoomId.equals(state.getChatRoomId()))
+        .forEach(this::leaveChatRoomPresence);
+  }
+
+  // 퇴장/연결 종료는 읽음 이벤트를 보내지 않고 DB 커서만 닫는다.
+  private void leaveChatRoomPresence(ChatUserState myState) {
+    myState.leaveChatRoom();
+    chatUserStateRepository.save(myState);
+  }
+
+  private void sendReadEventIfOpponentPresent(ChatUserState myState) {
+    ChatUserState opponentState = chatUserStateRepository
+        .findByChatRoomIdAndMemberIdNot(myState.getChatRoomId(), myState.getMemberId())
+        .orElse(null);
+    if (opponentState == null) {
+      log.warn("읽음 이벤트 전송 대상 상대방 상태를 찾을 수 없습니다. roomId={}, memberId={}",
+          myState.getChatRoomId(), myState.getMemberId());
+      return;
+    }
+
+    if (!opponentState.isDeleted() && opponentState.isPresent()) {
+      log.debug("상대방이 현재 화면에 있으므로, 읽음 이벤트를 브로커로 송출합니다. roomId={}, memberId={}",
+          myState.getChatRoomId(), myState.getMemberId());
+      chatWebSocketService.sendReadEvent(myState);
+    }
+  }
 
   /**
    * ChatRoom 슬라이스로부터 벌크 데이터를 조회하고, 삭제/나간 채팅방을 필터링한 뒤

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatControllerDocs.java
@@ -189,7 +189,7 @@ public interface ChatControllerDocs {
   ResponseEntity<ChatRoomResponse> getRecentMessages(ChatRoomRequest request, CustomUserDetails customUserDetails);
 
   @ApiChangeLogs({
-      @ApiChangeLog(date = "2026.04.30", author = Author.WISEUNGJAE, issueNumber = 0, description = "웹소켓 연결 종료 시 active 채팅방 자동 퇴장 처리 추가"),
+      @ApiChangeLog(date = "2026.04.30", author = Author.WISEUNGJAE, issueNumber = 654, description = "웹소켓 연결 종료 시 active 채팅방 자동 퇴장 처리 추가"),
       @ApiChangeLog(date = "2026.03.14", author = Author.WISEUNGJAE, issueNumber = 572, description = "읽음 커서 갱신 시 leftAt 기반 실시간 읽음 이벤트 연동"),
       @ApiChangeLog(date = "2025.10.14", author = Author.WISEUNGJAE, issueNumber = 318, description = "채팅방별 읽지 않은 메시지 개수 제공")
   })

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatControllerDocs.java
@@ -189,6 +189,7 @@ public interface ChatControllerDocs {
   ResponseEntity<ChatRoomResponse> getRecentMessages(ChatRoomRequest request, CustomUserDetails customUserDetails);
 
   @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.04.30", author = Author.WISEUNGJAE, issueNumber = 0, description = "웹소켓 연결 종료 시 active 채팅방 자동 퇴장 처리 추가"),
       @ApiChangeLog(date = "2026.03.14", author = Author.WISEUNGJAE, issueNumber = 572, description = "읽음 커서 갱신 시 leftAt 기반 실시간 읽음 이벤트 연동"),
       @ApiChangeLog(date = "2025.10.14", author = Author.WISEUNGJAE, issueNumber = 318, description = "채팅방별 읽지 않은 메시지 개수 제공")
   })
@@ -205,7 +206,9 @@ public interface ChatControllerDocs {
       - 특정 방에 속한 사용자(본인)의 읽음 표시 갱신
       - isEntered가 true면 leftAt을 null로 갱신하여, 입장 상태로 변경합니다.
       - isEntered가 false면 퇴장이므로, 현재 시각으로 leftAt 갱신합니다.
-      - 서버는 leftAt(현재 입장 상태) 기반으로 마지막 읽은 메시지를 계산하여 WebSocket **읽음** 이벤트(`/sub/chat.read.{chatRoomId}`)를 발행합니다.
+      - 앱 강제종료/네트워크 단절 등으로 WebSocket 연결이 종료되면, 서버는 현재 `leftAt == null`인 채팅방을 자동 퇴장 처리합니다.
+      - 입장 시에는 상대방이 현재 채팅방에 있으면 WebSocket **읽음** 이벤트(`/sub/chat.read.{chatRoomId}`)를 발행합니다.
+      - 퇴장/연결 종료 시에는 읽음 표시 오작동을 막기 위해 `leftAt`만 갱신하고 읽음 이벤트는 발행하지 않습니다.
      
       ### leftAt이 null이면 현재 방 안에 있으므로 최신 메시지까지 읽은 것으로 간주합니다.
       ### leftAt이 존재하면 해당 시각 직전까지 읽은 것으로 간주합니다.

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatWebSocketControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatWebSocketControllerDocs.java
@@ -13,7 +13,7 @@ import me.suhsaechan.suhapilog.annotation.ApiChangeLogs;
 
 public interface ChatWebSocketControllerDocs {
   @ApiChangeLogs({
-      @ApiChangeLog(date = "2026.04.30", author = Author.WISEUNGJAE, issueNumber = 0, description = "웹소켓 연결 종료 시 active 채팅방 자동 퇴장 처리 문서 추가"),
+      @ApiChangeLog(date = "2026.04.30", author = Author.WISEUNGJAE, issueNumber = 654, description = "웹소켓 연결 종료 시 active 채팅방 자동 퇴장 처리 문서 추가"),
       @ApiChangeLog(date = "2026.04.10", author = Author.WISEUNGJAE, issueNumber = 635, description = "사용자 전용 채팅 AI 추천 이벤트 문서 추가"),
       @ApiChangeLog(date = "2026.03.26", author = Author.SUHSAECHAN, issueNumber = 588, description = "TEXT 메시지 비속어 감지 시 isProfanityDetected 경고 플래그 추가 (전송 차단 없음)"),
       @ApiChangeLog(date = "2026.03.14", author = Author.WISEUNGJAE, issueNumber = 572, description = "현재 구현 기준으로 채팅 웹소켓 문서 정리"),

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatWebSocketControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatWebSocketControllerDocs.java
@@ -13,6 +13,7 @@ import me.suhsaechan.suhapilog.annotation.ApiChangeLogs;
 
 public interface ChatWebSocketControllerDocs {
   @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.04.30", author = Author.WISEUNGJAE, issueNumber = 0, description = "웹소켓 연결 종료 시 active 채팅방 자동 퇴장 처리 문서 추가"),
       @ApiChangeLog(date = "2026.04.10", author = Author.WISEUNGJAE, issueNumber = 635, description = "사용자 전용 채팅 AI 추천 이벤트 문서 추가"),
       @ApiChangeLog(date = "2026.03.26", author = Author.SUHSAECHAN, issueNumber = 588, description = "TEXT 메시지 비속어 감지 시 isProfanityDetected 경고 플래그 추가 (전송 차단 없음)"),
       @ApiChangeLog(date = "2026.03.14", author = Author.WISEUNGJAE, issueNumber = 572, description = "현재 구현 기준으로 채팅 웹소켓 문서 정리"),
@@ -58,8 +59,9 @@ public interface ChatWebSocketControllerDocs {
             - 읽음 이벤트도 함께 수신하려면 `/sub/chat.read.{chatRoomId}` 를 추가 구독합니다.
             - 읽음 이벤트는 **클라이언트가 WebSocket으로 직접 보내는 이벤트가 아니라 서버가 발행하는 이벤트**입니다.
             - 주로 아래 상황에서 발행됩니다.
-              - 사용자가 REST API `/api/chat/rooms/read-cursor/update` 를 호출해 입장/퇴장 상태를 변경했을 때
+              - 사용자가 REST API `/api/chat/rooms/read-cursor/update` 를 호출해 채팅방에 입장했을 때
               - 새 메시지가 도착했고, 수신자가 현재 같은 채팅방 화면에 머물고 있을 때
+            - 채팅방 퇴장 또는 WebSocket 연결 종료 시에는 `leftAt`만 갱신하고, 읽음 표시 오작동을 막기 위해 이 이벤트를 발행하지 않습니다.
             - 읽음 이벤트 payload 는 `ChatUserState` 기준입니다.
             - 주요 필드
               - `chatUserStateId`: 사용자 채팅방 상태 문서 ID
@@ -81,18 +83,6 @@ public interface ChatWebSocketControllerDocs {
                 "leftAt": null,
                 "removedAt": null,
                 "isPresent": true
-              }
-              ```
-            - 읽음 이벤트 예시 2. 상대방이 채팅방에서 나간 경우
-              - 의미: 상대방이 `2026-03-14T11:25:10` 시점에 채팅방 화면을 이탈한 상태
-              ```json
-              {
-                "chatUserStateId": "67d3ef9ad8b93f49d4c50cff",
-                "chatRoomId": "7d52df85-e88f-4344-bb68-a6f0dc1e03fb",
-                "memberId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "leftAt": "2026-03-14T11:25:10",
-                "removedAt": null,
-                "isPresent": false
               }
               ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * WebSocket 예기치 않은 연결 해제 시 활성 채팅방에서 자동으로 사용자 제거
  * 세션 종료 시 모든 활성 채팅방을 일괄로 떠나는 지원 추가

* **버그 수정**
  * 채팅방 입장/퇴장 로직 안정화 및 상대 상태 처리 개선
  * 연결 해제 시 불필요한 읽음 이벤트 발행 방지

* **문서**
  * WebSocket 읽음 커서 동작 및 관련 동작 설명 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->