### PR TITLE
물품관리_페이지_이미지_미표시_응답_필드_매핑_수정_및_기본_썸네일_노출_필요 : feat : 관리자 물품 목록/상세 응답 …

### DIFF
--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/ItemRepositoryImpl.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/ItemRepositoryImpl.java
@@ -23,7 +23,9 @@ import com.romrom.common.entity.postgres.QEmbedding;
 import com.romrom.common.util.QueryDslUtil;
 import com.romrom.item.config.RecommendationConfig;
 import com.romrom.item.entity.postgres.Item;
+import com.romrom.item.entity.postgres.ItemImage;
 import com.romrom.item.entity.postgres.QItem;
+import com.romrom.item.entity.postgres.QItemImage;
 import com.romrom.item.entity.postgres.UserInteractionScore;
 import com.romrom.member.entity.Member;
 import com.romrom.item.entity.postgres.QHiddenItem;
@@ -32,10 +34,12 @@ import com.romrom.member.entity.QMemberBlock;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -370,7 +374,41 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
     List<Item> items = dataQuery.getResultList();
     Long total = ((Number) countQuery.getSingleResult()).longValue();
 
+    // itemImages 는 OneToMany(LAZY) 라 native SQL 결과만으로는 미초기화됨.
+    // OSIV=false 환경에서 응답 직렬화 시점에 lazy 로딩이 불가능하므로
+    // 트랜잭션 내에서 IN 쿼리 한 번으로 일괄 페치 후 각 Item 에 주입한다.
+    fetchItemImagesForAdmin(items);
+
     return new PageImpl<>(items, pageable, total);
+  }
+
+  /**
+   * 관리자 물품 목록의 itemImages 컬렉션을 일괄 로드하여 각 Item 에 주입한다. (N+1 방지)
+   */
+  private void fetchItemImagesForAdmin(List<Item> items) {
+    if (items == null || items.isEmpty()) {
+      return;
+    }
+
+    List<UUID> itemIds = items.stream()
+        .map(Item::getItemId)
+        .toList();
+
+    QItemImage itemImage = QItemImage.itemImage;
+    List<ItemImage> fetchedItemImages = queryFactory
+        .selectFrom(itemImage)
+        .where(itemImage.item.itemId.in(itemIds))
+        .fetch();
+
+    // ItemImage.item 은 LAZY 프록시 — 식별자 접근만 하므로 추가 쿼리 발생하지 않음
+    Map<UUID, List<ItemImage>> itemImagesByItemId = fetchedItemImages.stream()
+        .collect(Collectors.groupingBy(image -> image.getItem().getItemId()));
+
+    items.forEach(loadedItem ->
+        loadedItem.setItemImages(
+            itemImagesByItemId.getOrDefault(loadedItem.getItemId(), new ArrayList<>())
+        )
+    );
   }
 
   /**

--- a/RomRom-Web/src/main/resources/templates/admin/items.html
+++ b/RomRom-Web/src/main/resources/templates/admin/items.html
@@ -209,6 +209,31 @@
         // 상세보기용 아이템 캐시
         let itemsCache = {};
 
+        // 기본 썸네일 경로 (이미지 미존재/로드 실패 시 노출)
+        const DEFAULT_ITEM_THUMBNAIL_URL = '/assets/img/default-150x150.png';
+
+        // 응답 스키마(itemImages[].imageUrl)에서 대표 썸네일 URL 추출
+        function getItemThumbnailUrl(item) {
+            const itemImageList = item && item.itemImages;
+            if (!Array.isArray(itemImageList) || itemImageList.length === 0) return null;
+            const firstItemImage = itemImageList[0];
+            return firstItemImage && firstItemImage.imageUrl ? firstItemImage.imageUrl : null;
+        }
+
+        // 응답 스키마(member.nickname)에서 판매자 닉네임 추출
+        function getItemSellerNickname(item) {
+            return item && item.member && item.member.nickname ? item.member.nickname : null;
+        }
+
+        // 썸네일 <img> 마크업 생성 — onerror 로 기본 썸네일 폴백 처리
+        function buildItemThumbnailImgTag(item, options) {
+            const thumbnailUrl = getItemThumbnailUrl(item) || DEFAULT_ITEM_THUMBNAIL_URL;
+            const cssClassName = options && options.className ? options.className : '';
+            const altText = options && options.alt ? options.alt : '물품 이미지';
+            return `<img src="${escapeHtml(thumbnailUrl)}" alt="${escapeHtml(altText)}" class="${cssClassName}"
+                onerror="if (this.src.indexOf('${DEFAULT_ITEM_THUMBNAIL_URL}') === -1) { this.src='${DEFAULT_ITEM_THUMBNAIL_URL}'; }"/>`;
+        }
+
         document.addEventListener('DOMContentLoaded', function() {
             loadItems();
 
@@ -299,16 +324,17 @@
                 tbody.innerHTML = itemsPage.content.map(item => {
                     const shortId = escapeHtml(item.itemId.substring(0, 8));
                     const status = statusMap[item.itemStatus] || {text: escapeHtml(item.itemStatus) || '-', cls:'badge-neutral'};
-                    const imgHtml = item.mainImageUrl
-                        ? `<div class="avatar"><div class="w-10 rounded"><img src="${escapeHtml(item.mainImageUrl)}" alt="물품"/></div></div>`
-                        : '<span class="badge badge-ghost badge-sm">없음</span>';
+                    // 응답에 itemImages[0].imageUrl 이 없거나 로드 실패 시 기본 썸네일로 폴백
+                    const thumbnailImgTag = buildItemThumbnailImgTag(item, { alt: '물품 썸네일' });
+                    const imgHtml = `<div class="avatar"><div class="w-10 rounded">${thumbnailImgTag}</div></div>`;
+                    const sellerNickname = getItemSellerNickname(item);
 
                     return `
                         <tr>
                             <td class="text-xs font-mono">${shortId}</td>
                             <td>${imgHtml}</td>
                             <td class="max-w-40 truncate">${escapeHtml(item.itemName) || '-'}</td>
-                            <td>${escapeHtml(item.sellerNickname) || '-'}</td>
+                            <td>${sellerNickname ? escapeHtml(sellerNickname) : '-'}</td>
                             <td>${item.price ? item.price.toLocaleString() + '원' : '-'}</td>
                             <td>${categoryMap[item.itemCategory] || '-'}</td>
                             <td>${conditionMap[item.itemCondition] || '-'}</td>
@@ -410,8 +436,19 @@
             const item = itemsCache[itemId];
             if (item) {
                 const status = statusMap[item.itemStatus] || {text: escapeHtml(item.itemStatus) || '-', cls:'badge-neutral'};
+                const sellerNickname = getItemSellerNickname(item);
+                // 등록 이미지 목록 — 빈 배열이면 기본 썸네일 1장 노출
+                const itemImageList = Array.isArray(item.itemImages) && item.itemImages.length > 0
+                    ? item.itemImages
+                    : [{ imageUrl: DEFAULT_ITEM_THUMBNAIL_URL }];
+                const galleryHtml = itemImageList.map(itemImage => {
+                    const imageUrl = itemImage && itemImage.imageUrl ? itemImage.imageUrl : DEFAULT_ITEM_THUMBNAIL_URL;
+                    return `<img src="${escapeHtml(imageUrl)}" alt="물품 이미지" class="w-24 h-24 object-cover rounded-lg border border-base-300"
+                        onerror="if (this.src.indexOf('${DEFAULT_ITEM_THUMBNAIL_URL}') === -1) { this.src='${DEFAULT_ITEM_THUMBNAIL_URL}'; }"/>`;
+                }).join('');
+
                 content.innerHTML = `
-                    ${item.mainImageUrl ? `<img src="${escapeHtml(item.mainImageUrl)}" alt="물품" class="w-full max-w-sm rounded-lg mb-4"/>` : ''}
+                    <div class="flex flex-wrap gap-2 mb-4">${galleryHtml}</div>
                     <div class="grid grid-cols-2 gap-2 text-sm">
                         <div class="text-base-content/60">물품 ID</div><div class="font-mono text-xs">${escapeHtml(item.itemId)}</div>
                         <div class="text-base-content/60">물품명</div><div class="font-medium">${escapeHtml(item.itemName) || '-'}</div>
@@ -421,7 +458,7 @@
                         <div class="text-base-content/60">거래 상태</div><div><span class="badge ${status.cls} badge-sm">${status.text}</span></div>
                         <div class="text-base-content/60">가격</div><div>${item.price ? item.price.toLocaleString() + '원' : '-'}</div>
                         <div class="text-base-content/60">좋아요</div><div>${item.likeCount || 0}개</div>
-                        <div class="text-base-content/60">판매자</div><div>${escapeHtml(item.sellerNickname) || '-'}</div>
+                        <div class="text-base-content/60">판매자</div><div>${sellerNickname ? escapeHtml(sellerNickname) : '-'}</div>
                         <div class="text-base-content/60">등록일</div><div>${TimeUtils.formatDateTime(item.createdDate)}</div>
                     </div>
                 `;

--- a/RomRom-Web/src/main/resources/templates/admin/member-detail.html
+++ b/RomRom-Web/src/main/resources/templates/admin/member-detail.html
@@ -37,7 +37,8 @@
                     <!-- 프로필 이미지 -->
                     <div class="avatar">
                         <div class="w-20 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-                            <img id="profileImg" src="/assets/img/default-150x150.png" alt="프로필"/>
+                            <img id="profileImg" src="/assets/img/default-150x150.png" alt="프로필"
+                                 onerror="if (this.src.indexOf('/assets/img/default-150x150.png') === -1) { this.src='/assets/img/default-150x150.png'; }"/>
                         </div>
                     </div>
 

--- a/RomRom-Web/src/main/resources/templates/admin/members.html
+++ b/RomRom-Web/src/main/resources/templates/admin/members.html
@@ -152,9 +152,10 @@
 
             if (membersPage.content && membersPage.content.length > 0) {
                 tbody.innerHTML = membersPage.content.map(m => {
-                    const profileImg = m.profileUrl
-                        ? `<img src="${escapeHtml(m.profileUrl)}" alt="프로필"/>`
-                        : `<img src="/assets/img/default-150x150.png" alt="프로필"/>`;
+                    // 프로필 URL 이 없거나 깨진 URL 이면 기본 썸네일로 폴백
+                    const profileImageUrl = m.profileUrl ? m.profileUrl : '/assets/img/default-150x150.png';
+                    const profileImg = `<img src="${escapeHtml(profileImageUrl)}" alt="프로필"
+                        onerror="if (this.src.indexOf('/assets/img/default-150x150.png') === -1) { this.src='/assets/img/default-150x150.png'; }"/>`;
                     const isActive = !m.isDeleted;
 
                     return `


### PR DESCRIPTION
…매핑 수정 및 기본 썸네일 폴백 도입 https://github.com/TEAM-ROMROM/RomRom-BE/issues/677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 물품 목록에서 이미지 로드 실패 시 기본 썸네일로 자동 표시
  * 회원 목록 및 회원 상세 페이지에서 프로필 이미지 로드 실패 시 기본 이미지로 폴백
* **개선**
  * 물품 목록 및 상세 모달에서 판매자 닉네임이 올바르게 표시되도록 개선
  * 물품 상세 모달의 이미지 갤러리/썸네일 표시 방식 개선으로 이미지가 더 안정적으로 로드됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->