### PR TITLE
api_trade_review_get_응답의_reviewerMember_위치정보_null_반환 : fix : getRecei…

### DIFF
--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/TradeReviewService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/TradeReviewService.java
@@ -10,6 +10,8 @@ import com.romrom.item.entity.postgres.TradeReview;
 import com.romrom.item.repository.postgres.TradeRequestHistoryRepository;
 import com.romrom.item.repository.postgres.TradeReviewRepository;
 import com.romrom.member.entity.Member;
+import com.romrom.member.entity.MemberLocation;
+import com.romrom.member.repository.MemberLocationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -20,6 +22,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -29,6 +32,7 @@ public class TradeReviewService {
 
   private final TradeReviewRepository tradeReviewRepository;
   private final TradeRequestHistoryRepository tradeRequestHistoryRepository;
+  private final MemberLocationRepository memberLocationRepository;
 
   // 후기 작성
   @Transactional
@@ -108,6 +112,16 @@ public class TradeReviewService {
       request.getMemberId(),
       pageRequest
     );
+
+    // reviewerMember의 @Transient 위치 정보 수동 설정 (MemberLocation 별도 조회 필요)
+    tradeReviewPage.forEach(tradeReview -> {
+      Member reviewerMember = tradeReview.getReviewerMember();
+      Optional<MemberLocation> reviewerLocationOptional = memberLocationRepository.findByMemberMemberId(reviewerMember.getMemberId());
+      reviewerLocationOptional.ifPresent(reviewerLocation -> {
+        reviewerMember.setLatitude(reviewerLocation.getLatitude());
+        reviewerMember.setLongitude(reviewerLocation.getLongitude());
+      });
+    });
 
     return TradeResponse.builder()
         .tradeReviewPage(tradeReviewPage)


### PR DESCRIPTION
…vedTradeReviews에서 reviewerMember의 @Transient 위치 정보를 MemberLocation으로부터 수동 설정하도록 수정 https://github.com/TEAM-ROMROM/RomRom-BE/issues/691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 거래 리뷰 응답에 검토자의 위치 정보가 추가되어 더욱 상세한 리뷰 정보를 제공합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-ROMROM/RomRom-BE/pull/692)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->