### PR TITLE
memberId_기반_회원_등록_물품_조회_API_추가 : feat : ItemRequest에 memberId 필드 추가, …

### DIFF
--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/dto/ItemRequest.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/dto/ItemRequest.java
@@ -72,6 +72,9 @@ public class ItemRequest {
   @Schema(description = "물품 ID")
   private UUID itemId;
 
+  @Schema(description = "회원 ID")
+  private UUID memberId;
+
   @Schema(description = "AI 가격측정 여부", defaultValue = "false")
   private Boolean isAiPredictedPrice;
 

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/ItemRepository.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/ItemRepository.java
@@ -26,6 +26,8 @@ public interface ItemRepository extends JpaRepository<Item, UUID>, ItemRepositor
 
   Page<Item> findAllByMemberAndIsDeletedFalse(Member member, Pageable pageable);
 
+  Page<Item> findAllByMemberMemberIdAndIsDeletedFalse(UUID memberId, Pageable pageable);
+
   @Query("select i.itemId from Item i " +
          "where i.member = :member " +
          "and i.isDeleted = false " +

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
@@ -352,6 +352,10 @@ public class ItemService {
       throw new CustomException(ErrorCode.SUSPENDED_MEMBER);
     }
 
+    // 요청 회원과 대상 회원 간 차단 관계 검증
+    UUID targetMemberId = request.getMemberId();
+    memberBlockService.verifyNotBlocked(request.getMember().getMemberId(), targetMemberId);
+
     Pageable pageable = PageRequest.of(
         request.getPageNumber(),
         request.getPageSize(),

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
@@ -329,6 +329,43 @@ public class ItemService {
         .build();
   }
 
+  // memberId 기반 회원 등록 물품 페이지 조회
+  @Transactional(readOnly = true)
+  public ItemResponse getMemberItemsByMemberId(ItemRequest request) {
+    if (request.getMemberId() == null) {
+      log.error("물품 조회 대상 memberId가 누락되었습니다.");
+      throw new CustomException(ErrorCode.INVALID_REQUEST);
+    }
+
+    Member targetMember = memberRepository.findById(request.getMemberId())
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    // 탈퇴한 회원의 물품 조회 차단
+    if (targetMember.getAccountStatus() == AccountStatus.DELETE_ACCOUNT) {
+      log.debug("탈퇴한 회원의 물품 조회 시도 차단: memberId={}", targetMember.getMemberId());
+      throw new CustomException(ErrorCode.DELETED_MEMBER);
+    }
+
+    // 정지된 회원의 물품 조회 차단
+    if (targetMember.getAccountStatus() == AccountStatus.SUSPENDED_ACCOUNT) {
+      log.debug("정지된 회원의 물품 조회 시도 차단: memberId={}", targetMember.getMemberId());
+      throw new CustomException(ErrorCode.SUSPENDED_MEMBER);
+    }
+
+    Pageable pageable = PageRequest.of(
+        request.getPageNumber(),
+        request.getPageSize(),
+        Sort.by(Direction.DESC, "createdDate")
+    );
+
+    Page<Item> itemPage = itemRepository.findAllByMemberMemberIdAndIsDeletedFalse(
+        request.getMemberId(), pageable);
+
+    return ItemResponse.builder()
+        .itemPage(itemPage)
+        .build();
+  }
+
   /**
    * 물품 상세 조회
    *

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemController.java
@@ -85,6 +85,16 @@ public class ItemController implements ItemControllerDocs {
   }
 
   @Override
+  @PostMapping(value = "/get/member", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @LogMonitor
+  public ResponseEntity<ItemResponse> getMemberItems(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @ModelAttribute ItemRequest request) {
+    request.setMember(customUserDetails.getMember());
+    return ResponseEntity.ok(itemService.getMemberItemsByMemberId(request));
+  }
+
+  @Override
   @PostMapping(value = "/list/get", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @LogMonitor
   public ResponseEntity<ItemResponse> getItemList(

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemControllerDocs.java
@@ -745,6 +745,7 @@ public interface ItemControllerDocs {
           ## 에러 응답
           - **HTTP 400**: memberId 누락
           - **HTTP 403**: 탈퇴 회원 또는 정지 회원의 물품 조회 시도
+          - **HTTP 403**: 요청 회원과 대상 회원 간 차단 관계 존재
           - **HTTP 404**: 존재하지 않는 회원 ID
           """
   )

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ItemControllerDocs.java
@@ -727,6 +727,33 @@ public interface ItemControllerDocs {
   );
 
   @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.05.11", author = Author.BAEKJIHOON, issueNumber = 694, description = "memberId 기반 회원 등록 물품 조회 API 추가"),
+  })
+  @Operation(
+      summary = "memberId 기반 회원 등록 물품 조회",
+      description = """
+          ## 인증(JWT): **필요**
+
+          ## 요청 파라미터 (ItemRequest)
+          - **`memberId (UUID)`**: 조회할 회원 ID
+          - **`pageNumber`**: 인덱스 번호 (기본값: 0)
+          - **`pageSize`**: 한 페이지에 반환할 데이터 개수 (기본값: 30)
+
+          ## 반환값 (ItemResponse)
+          - **`itemPage`**: 페이지네이션된 물품 목록 (최신순 정렬)
+
+          ## 에러 응답
+          - **HTTP 400**: memberId 누락
+          - **HTTP 403**: 탈퇴 회원 또는 정지 회원의 물품 조회 시도
+          - **HTTP 404**: 존재하지 않는 회원 ID
+          """
+  )
+  ResponseEntity<ItemResponse> getMemberItems(
+      CustomUserDetails customUserDetails,
+      ItemRequest request
+  );
+
+  @ApiChangeLogs({
       @ApiChangeLog(date = "2026.01.03", author = Author.WISEUNGJAE, issueNumber = 428, description = "차단된 회원의 물품 조회 방지 로직 추가"),
       @ApiChangeLog(date = "2025.10.29", author = Author.KIMNAYOUNG, issueNumber = 373, description = "좋아요 목록 리스트"),
   })


### PR DESCRIPTION
…ItemRepository에 페이징 쿼리 추가, ItemService에 getMemberItemsByMemberId 서비스 메서드 추가, ItemController에 /api/item/get/member 엔드포인트 추가, ItemControllerDocs Swagger 문서 추가 https://github.com/TEAM-ROMROM/RomRom-BE/issues/694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회원 ID를 기반으로 등록된 물품을 조회할 수 있는 기능 추가
  * 페이징 지원으로 물품 목록을 효율적으로 조회 가능
  * 탈퇴 또는 정지된 계정의 물품 조회 방지

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-ROMROM/RomRom-BE/pull/695)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->