### PR TITLE
대시보드 통계 데이터 진행중거래 신고접수 등 실제 데이터 연동 필요 : feat : 관리자 대시보드 stats에 진행중거래(…

### DIFF
--- a/RomRom-Application/src/main/java/com/romrom/application/dto/AdminResponse.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/dto/AdminResponse.java
@@ -227,5 +227,11 @@ public class AdminResponse {
 
         @Schema(description = "오늘 등록 물품 수")
         private Long todayNewItems;
+
+        @Schema(description = "진행중 거래 건수 (PENDING + CHATTING + TRADE_COMPLETE_REQUESTED)")
+        private Long ongoingTrades;
+
+        @Schema(description = "신고접수 건수 (물품+회원 PENDING 합산)")
+        private Long pendingReports;
     }
 }

--- a/RomRom-Application/src/main/java/com/romrom/application/service/AdminReportService.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/service/AdminReportService.java
@@ -100,6 +100,16 @@ public class AdminReportService {
     return AdminResponse.builder().build();
   }
 
+  /**
+   * 신고접수(PENDING) 건수 조회 (관리자 대시보드용)
+   * - 물품 신고 + 회원 신고 PENDING 합산
+   */
+  @Transactional(readOnly = true)
+  public long countPendingReports() {
+    return itemReportRepository.countByStatus(ReportStatus.PENDING)
+        + memberReportRepository.countByStatus(ReportStatus.PENDING);
+  }
+
   @Transactional(readOnly = true)
   public AdminResponse getStats() {
     Map<String, Long> itemStats = new LinkedHashMap<>();

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/TradeRequestHistoryRepository.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/TradeRequestHistoryRepository.java
@@ -4,6 +4,7 @@ import com.romrom.common.constant.TradeStatus;
 import com.romrom.item.entity.postgres.Item;
 import com.romrom.item.entity.postgres.TradeRequestHistory;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -118,4 +119,6 @@ public interface TradeRequestHistoryRepository extends JpaRepository<TradeReques
       "JOIN FETCH t.giveItem gi " +
       "WHERE t.tradeRequestHistoryId = :tradeRequestHistoryId")
   Optional<TradeRequestHistory> findByTradeRequestHistoryIdWithItems(UUID tradeRequestHistoryId);
+
+  long countByTradeStatusIn(Collection<TradeStatus> statuses);
 }

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/ItemService.java
@@ -10,6 +10,7 @@ import com.romrom.common.constant.ItemSortField;
 import com.romrom.common.constant.ItemStatus;
 import com.romrom.common.constant.LikeContentType;
 import com.romrom.common.constant.OriginalType;
+import com.romrom.common.constant.TradeStatus;
 import com.romrom.common.entity.postgres.Embedding;
 import com.romrom.common.exception.CustomException;
 import com.romrom.common.exception.ErrorCode;
@@ -777,6 +778,16 @@ public class ItemService {
   @Transactional(readOnly = true)
   public long countActiveItems() {
     return itemRepository.count();
+  }
+
+  /**
+   * 진행중 거래 건수 조회 (관리자용)
+   * - PENDING, CHATTING, TRADE_COMPLETE_REQUESTED 상태 합산
+   */
+  @Transactional(readOnly = true)
+  public long countOngoingTrades() {
+    return tradeRequestHistoryRepository.countByTradeStatusIn(
+        List.of(TradeStatus.PENDING, TradeStatus.CHATTING, TradeStatus.TRADE_COMPLETE_REQUESTED));
   }
 
   /**

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AdminApiController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AdminApiController.java
@@ -113,6 +113,8 @@ public class AdminApiController {
             .dashboardStats(AdminResponse.AdminDashboardStats.builder()
                 .totalMembers(memberService.countActiveMembers())
                 .totalItems(itemService.countActiveItems())
+                .ongoingTrades(itemService.countOngoingTrades())
+                .pendingReports(adminReportService.countPendingReports())
                 .build())
             .build());
     }


### PR DESCRIPTION
…PENDING/CHATTING/TRADE_COMPLETE_REQUESTED) 및 신고접수(PENDING) 건수 실제 데이터 연동 https://github.com/TEAM-ROMROM/RomRom-BE/issues/553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자 대시보드에 두 가지 새로운 통계 지표가 추가되었습니다.
    * 진행 중 거래 건수: 대기, 채팅, 거래 완료 요청 상태의 거래 통계
    * 신고 접수 대기 건수: 물품 및 회원 신고 중 대기 상태의 신고 통계

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-ROMROM/RomRom-BE/pull/698)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->