### PR TITLE
20260602_#745_채팅_에러_핸들러에서_NPE_무조건_발생 : feat : getCause() null 체크로 NPE 방어 및 미사용 ObjectMapper 제거 https://github.com/TEAM-ROMROM/RomRom-BE/issues/745

### DIFF
--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/stomp/exception/CustomStompProtocolErrorHandler.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/stomp/exception/CustomStompProtocolErrorHandler.java
@@ -19,9 +19,12 @@ public class CustomStompProtocolErrorHandler extends StompSubProtocolErrorHandle
 
   @Override
   public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
-    // getCause()가 null일 수 있으므로 원본 예외 메시지를 fallback으로 사용
+    // cause/getMessage() 모두 null일 수 있으므로 최종 fallback으로 클래스명 사용
     Throwable cause = ex.getCause();
-    String errorMessage = (cause != null) ? cause.getMessage() : ex.getMessage();
+    String errorMessage =
+        (cause != null && cause.getMessage() != null) ? cause.getMessage()
+            : (ex.getMessage() != null) ? ex.getMessage()
+            : ex.getClass().getSimpleName();
 
     log.error("웹소켓 오류 발생: {}", ex.getMessage());
 

--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/stomp/exception/CustomStompProtocolErrorHandler.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/stomp/exception/CustomStompProtocolErrorHandler.java
@@ -1,8 +1,6 @@
 package com.romrom.chat.stomp.exception;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -17,20 +15,21 @@ import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
  */
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class CustomStompProtocolErrorHandler extends StompSubProtocolErrorHandler {
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Override
   public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+    // getCause()가 null일 수 있으므로 원본 예외 메시지를 fallback으로 사용
     Throwable cause = ex.getCause();
+    String errorMessage = (cause != null) ? cause.getMessage() : ex.getMessage();
+
     log.error("웹소켓 오류 발생: {}", ex.getMessage());
+
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
-    accessor.setMessage("CustomException: " + cause.getMessage());
+    accessor.setMessage("CustomException: " + errorMessage);
     accessor.setLeaveMutable(true);
 
-    String payload = "CustomException 발생: " + cause.getMessage();
+    String payload = "CustomException 발생: " + errorMessage;
     byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
 
     return MessageBuilder.createMessage(bytes, accessor.getMessageHeaders());


### PR DESCRIPTION
## Summary

`CustomStompProtocolErrorHandler.handleClientMessageProcessingError`에서 `ex.getCause()`가 `null`을 반환할 때 `cause.getMessage()` 호출로 NPE가 무조건 발생하는 문제를 수정한다. 아울러 동일 파일의 미사용 `ObjectMapper` 필드를 제거한다.

## Changes

- **NPE 방어**: `ex.getCause()` null 체크 후 null이면 `ex.getMessage()`로 fallback
- **미사용 필드 제거**: `private final ObjectMapper objectMapper = new ObjectMapper()` 삭제
- **불필요 어노테이션 제거**: `@RequiredArgsConstructor` 및 관련 import 삭제

## Files Changed

| 파일 | 변경 유형 |
|------|-----------|
| `RomRom-Domain-Chat/.../stomp/exception/CustomStompProtocolErrorHandler.java` | Modified |

## Testing

- `./gradlew :RomRom-Domain-Chat:compileJava` → BUILD SUCCESSFUL
- Review 판정: PASS

## Artifacts

- `.report/20260602_#745_채팅_에러핸들러_NPE_수정.md`

## Related Issues

Closes #745


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * STOMP 프로토콜 오류 처리 시 예외 메시지가 항상 정상적으로 표시되도록 개선했습니다.
  * 오류 응답 프레임의 메시지 구성 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->