### PR TITLE
20260602_#747_채팅방_입장_시_상태_저장_완료_전에_읽음_이벤트가_발송됨 : feat : 채팅방 입장 상태 저장 완료 후 읽음 이벤트 발송되도록 afterCommit 콜백 적용 https://github.com/TEAM-ROMROM/RomRom-BE/issues/747

### DIFF
--- a/RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatRoomService.java
+++ b/RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatRoomService.java
@@ -198,7 +198,13 @@ public class ChatRoomService {
       leaveOtherActiveChatRooms(memberId, chatRoomId);
       myState.enterChatRoom();
       chatUserStateRepository.save(myState);
-      sendReadEventIfOpponentPresent(myState);
+      // 상태 저장 커밋 완료 후 읽음 이벤트 발송 (ChatMessageService.registerMessageDispatch 와 동일한 패턴)
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCommit() {
+          sendReadEventIfOpponentPresent(myState);
+        }
+      });
     } else {
       leaveChatRoomPresence(myState);
     }


### PR DESCRIPTION
## Summary

`enterOrLeaveChatRoom` 메서드에서 채팅방 입장 상태 저장이 완료되기 전에 읽음 이벤트가 발송되던 문제를 수정합니다. MongoDB 트랜잭션 커밋 이후에 읽음 이벤트가 발송되도록 `afterCommit()` 콜백 패턴을 적용했습니다.

## Changes

- **ChatRoomService**: `enterOrLeaveChatRoom`에서 `sendReadEventIfOpponentPresent()` 호출을 `TransactionSynchronizationManager.registerSynchronization` → `afterCommit()` 콜백으로 래핑
  - 기존: 상태 저장(`chatUserStateRepository.save(myState)`) 직후 즉시 읽음 이벤트 발송
  - 수정: 트랜잭션 커밋 완료 후 읽음 이벤트 발송 (`ChatMessageService.registerMessageDispatch`와 동일한 패턴 적용)

## Files Changed

| 파일 | 변경 유형 |
|------|-----------|
| `RomRom-Domain-Chat/src/main/java/com/romrom/chat/service/ChatRoomService.java` | Modified (+7 / -1) |

## Testing

- `./gradlew :RomRom-Domain-Chat:compileJava` 빌드 확인 완료 (BUILD SUCCESSFUL)
- 신규 import 불필요 (`TransactionSynchronization`, `TransactionSynchronizationManager` 이미 존재)

## Related Artifacts

- `.report/20260602_채팅_로직_버그_분석_보고서.md` — BUG-03 항목 참조

## Related Issues

Closes #747


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅방 입장 시 상대방에게 전송되는 읽음 이벤트의 안정성을 개선했습니다. 사용자 간의 읽음 상태 표시가 더욱 정확해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->