### PR TITLE
20260602_#752_채팅_메시지_전송_컨트롤러에서_세션_속성_null_시_NPE_발생 : feat : sessionAttributes null 체크 추가로 NPE 방지 및 UNAUTHORIZED 예외 처리 https://github.com/TEAM-ROMROM/RomRom-BE/issues/752

### DIFF
--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatWebSocketController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatWebSocketController.java
@@ -8,6 +8,7 @@ import com.romrom.chat.service.ChatMessageService;
 import com.romrom.common.exception.CustomException;
 import com.romrom.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -32,11 +33,12 @@ public class ChatWebSocketController implements ChatWebSocketControllerDocs {
   // WebsocketConfig 에서 설정한 applicationDestinationPrefixes("/app")가 붙음
   @MessageMapping("/chat.send")
   public void send(ChatMessageRequest request, StompHeaderAccessor accessor) {
-    CustomUserDetails customUserDetails = (CustomUserDetails) accessor.getSessionAttributes().get(SESSION_USER_KEY);
-    if (customUserDetails == null) {
+    Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+    if (sessionAttributes == null || sessionAttributes.get(SESSION_USER_KEY) == null) {
       log.error("세션에서 사용자 정보를 찾을 수 없습니다. 인증된 사용자가 아닙니다.");
       throw new CustomException(ErrorCode.UNAUTHORIZED);
     }
+    CustomUserDetails customUserDetails = (CustomUserDetails) sessionAttributes.get(SESSION_USER_KEY);
     customUserDetails.validateExpiration();
     chatMessageService.saveAndSendMessage(request, customUserDetails);
   }


### PR DESCRIPTION
## Summary

`ChatWebSocketController.send()`에서 `accessor.getSessionAttributes()`가 `null`을 반환할 경우 NPE가 발생하던 버그를 수정합니다.
`sessionAttributes` null 체크를 추가하여 의도된 `UNAUTHORIZED` 예외가 발생하도록 처리합니다.

## Changes

- **RomRom-Web / ChatWebSocketController**
  - `accessor.getSessionAttributes()`를 지역 변수로 분리
  - `sessionAttributes == null` 또는 `SESSION_USER_KEY` 미존재 시 `CustomException(UNAUTHORIZED)` 발생
  - 기존 `customUserDetails == null` 체크를 위 조건으로 통합

## Files Changed

| 파일 | 변경 유형 |
|---|---|
| `RomRom-Web/src/main/java/com/romrom/web/controller/api/ChatWebSocketController.java` | Modified |

## Testing

- `./gradlew :RomRom-Web:compileJava` — BUILD SUCCESSFUL 확인

## Related Issues

Closes #752


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채팅 연결 시 세션 검증 로직을 개선하여 인증 오류 처리의 신뢰성을 높였습니다. 세션 정보 부재 또는 손상 상황에서 더욱 안정적으로 처리되도록 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->