### PR TITLE
Admin 대시보드 통합 개편 및 후기 블라인드 관리

### DIFF
--- a/RomRom-Application/src/main/java/com/romrom/application/dto/AdminRequest.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/dto/AdminRequest.java
@@ -5,6 +5,7 @@ import com.romrom.common.constant.ItemAdminDeleteReason;
 import com.romrom.common.constant.ItemCategory;
 import com.romrom.common.constant.ItemCondition;
 import com.romrom.common.constant.ItemStatus;
+import com.romrom.common.constant.TradeReviewRating;
 import com.romrom.common.constant.TradeStatus;
 import com.romrom.report.enums.ReportStatus;
 import com.romrom.report.enums.ReportType;
@@ -207,6 +208,19 @@ public class AdminRequest {
 
     @Schema(description = "강제 취소/완료 사유 (force-cancel, force-complete 엔드포인트용)")
     private String adminTradeForceReason;
+
+    // 후기 관련 필드
+    @Schema(description = "후기 ID (블라인드/해제 시 사용)")
+    private UUID tradeReviewId;
+
+    @Schema(description = "후기 평점 필터 (목록 조회용: BAD/GOOD/GREAT, 미입력=전체)")
+    private TradeReviewRating tradeReviewRating;
+
+    @Schema(description = "블라인드 처리 사유 (blind 엔드포인트용)")
+    private String blindReason;
+
+    @Schema(description = "블라인드 여부 필터 (목록 조회용: true=블라인드만, false=정상만, 미입력=전체)")
+    private Boolean isBlindedFilter;
 
     // UGC 필터 관련 필드
     @Schema(description = "UGC 필터 정규식 패턴 목록 (JSON 배열 문자열, 예: [\"씨발\",\"fuck\"])")

--- a/RomRom-Application/src/main/java/com/romrom/application/dto/AdminResponse.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/dto/AdminResponse.java
@@ -1,8 +1,10 @@
 package com.romrom.application.dto;
 
 import com.romrom.chat.entity.postgres.ChatRoom;
+import com.romrom.common.constant.TradeStatus;
 import com.romrom.item.entity.postgres.Item;
 import com.romrom.item.entity.postgres.TradeRequestHistory;
+import com.romrom.item.entity.postgres.TradeReview;
 import com.romrom.member.entity.Member;
 import com.romrom.member.entity.mongo.SanctionHistory;
 import com.romrom.notification.entity.Announcement;
@@ -89,6 +91,13 @@ public class AdminResponse {
 
     @Schema(description = "거래 상세 정보 (detail 엔드포인트용)")
     private AdminTradeDetailDto tradeDetail;
+
+    @Schema(description = "최근 교환완료(TRADED) 거래 목록 (대시보드 recent-trades 용)")
+    private List<TradeRequestHistory> recentTrades;
+
+    // 후기 관련 응답 데이터
+    @Schema(description = "페이지네이션된 후기 목록 (관리자 후기 관리용, blindInfo 포함)")
+    private Page<TradeReview> reviews;
 
     // 공지사항 관련 응답 데이터
     @Schema(description = "공지사항 목록")
@@ -293,5 +302,11 @@ public class AdminResponse {
 
         @Schema(description = "신고접수 건수 (물품+회원 PENDING 합산)")
         private Long pendingReports;
+
+        @Schema(description = "거래 상태별 건수 (데이터 주도 카드 렌더용, 모든 TradeStatus 키 포함). 기간 필터 적용 시 해당 기간 집계")
+        private Map<TradeStatus, Long> tradeStatusCounts;
+
+        @Schema(description = "신규 후기 건수 (기간 필터 적용 시 해당 기간 작성 후기 수)")
+        private Long newReviewCount;
     }
 }

--- a/RomRom-Application/src/main/java/com/romrom/application/service/AdminDashboardService.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/service/AdminDashboardService.java
@@ -1,0 +1,108 @@
+package com.romrom.application.service;
+
+import com.romrom.application.dto.AdminRequest;
+import com.romrom.application.dto.AdminResponse;
+import com.romrom.common.constant.TradeStatus;
+import com.romrom.item.entity.postgres.TradeRequestHistory;
+import com.romrom.item.repository.postgres.TradeRequestHistoryRepository;
+import com.romrom.item.repository.postgres.TradeRequestHistoryRepository.TradeStatusCountProjection;
+import com.romrom.item.repository.postgres.TradeReviewRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관리자 대시보드 통계 조립 서비스
+ * - 거래 상태별 카운트(데이터 주도), 신규 후기 카운트, 최근 교환완료 거래
+ * - 기간 필터(startDate/endDate) 지원. 둘 다 없으면 전체 누적
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminDashboardService {
+
+  private static final DateTimeFormatter DASHBOARD_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  private final TradeRequestHistoryRepository tradeRequestHistoryRepository;
+  private final TradeReviewRepository tradeReviewRepository;
+
+  /**
+   * 거래 상태별 카운트 + 신규 후기 카운트 (기간 필터 적용)
+   * - 모든 TradeStatus 키를 0으로 초기화한 뒤 집계 결과를 덮어써, 건수 0인 상태도 카드로 노출되게 한다
+   */
+  @Transactional(readOnly = true)
+  public AdminResponse.AdminDashboardStats getTradeStatusStats(AdminRequest request) {
+    LocalDateTime startDateTime = parseStartDate(request.getStartDate());
+    LocalDateTime endDateTime = parseEndDate(request.getEndDate());
+
+    Map<TradeStatus, Long> tradeStatusCounts = new EnumMap<>(TradeStatus.class);
+    for (TradeStatus tradeStatus : TradeStatus.values()) {
+      tradeStatusCounts.put(tradeStatus, 0L);
+    }
+    for (TradeStatusCountProjection countProjection :
+        tradeRequestHistoryRepository.countGroupedByTradeStatus(startDateTime, endDateTime)) {
+      tradeStatusCounts.put(countProjection.getTradeStatus(), countProjection.getCount());
+    }
+
+    long newReviewCount = tradeReviewRepository.countByCreatedDateBetweenNullable(startDateTime, endDateTime);
+
+    log.info("대시보드 거래 상태별 통계 조회: 기간={}~{}, 후기={}건",
+        request.getStartDate(), request.getEndDate(), newReviewCount);
+
+    return AdminResponse.AdminDashboardStats.builder()
+        .tradeStatusCounts(tradeStatusCounts)
+        .newReviewCount(newReviewCount)
+        .build();
+  }
+
+  /**
+   * 최근 교환완료(TRADED) 거래 N건
+   */
+  @Transactional(readOnly = true)
+  public AdminResponse getRecentTrades(int recentTradeLimit) {
+    List<TradeRequestHistory> recentTrades =
+        tradeRequestHistoryRepository.findRecentTradedForAdmin(PageRequest.of(0, recentTradeLimit));
+
+    log.info("대시보드 최근 교환완료 거래 조회: {}건", recentTrades.size());
+
+    return AdminResponse.builder()
+        .recentTrades(recentTrades)
+        .build();
+  }
+
+  /**
+   * 기간 시작일 파싱: yyyy-MM-dd → 해당 일자 00:00:00
+   */
+  private LocalDateTime parseStartDate(String startDateString) {
+    LocalDate localDate = parseLocalDate(startDateString);
+    return localDate == null ? null : localDate.atStartOfDay();
+  }
+
+  /**
+   * 기간 종료일 파싱: yyyy-MM-dd → 해당 일자 23:59:59.999999999 (inclusive)
+   */
+  private LocalDateTime parseEndDate(String endDateString) {
+    LocalDate localDate = parseLocalDate(endDateString);
+    return localDate == null ? null : localDate.atTime(java.time.LocalTime.MAX);
+  }
+
+  private LocalDate parseLocalDate(String dateString) {
+    if (dateString == null || dateString.trim().isEmpty()) {
+      return null;
+    }
+    try {
+      return LocalDate.parse(dateString.trim(), DASHBOARD_DATE_FORMAT);
+    } catch (Exception e) {
+      log.warn("대시보드 날짜 파싱 실패: {}", dateString, e);
+      return null;
+    }
+  }
+}

--- a/RomRom-Application/src/main/java/com/romrom/application/service/AdminDashboardService.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/service/AdminDashboardService.java
@@ -3,6 +3,8 @@ package com.romrom.application.service;
 import com.romrom.application.dto.AdminRequest;
 import com.romrom.application.dto.AdminResponse;
 import com.romrom.common.constant.TradeStatus;
+import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.ErrorCode;
 import com.romrom.item.entity.postgres.TradeRequestHistory;
 import com.romrom.item.repository.postgres.TradeRequestHistoryRepository;
 import com.romrom.item.repository.postgres.TradeRequestHistoryRepository.TradeStatusCountProjection;
@@ -94,6 +96,10 @@ public class AdminDashboardService {
     return localDate == null ? null : localDate.atTime(java.time.LocalTime.MAX);
   }
 
+  /**
+   * yyyy-MM-dd 파싱. 미입력은 null(전체 기간), 형식 오류는 INVALID_REQUEST 로 끊는다.
+   * - 잘못된 날짜를 null 로 삼키면 "기간 오류"가 "전체 누적 조회"로 둔갑해 관리자에게 정상처럼 보임
+   */
   private LocalDate parseLocalDate(String dateString) {
     if (dateString == null || dateString.trim().isEmpty()) {
       return null;
@@ -101,8 +107,8 @@ public class AdminDashboardService {
     try {
       return LocalDate.parse(dateString.trim(), DASHBOARD_DATE_FORMAT);
     } catch (Exception e) {
-      log.warn("대시보드 날짜 파싱 실패: {}", dateString, e);
-      return null;
+      log.warn("대시보드 날짜 파싱 실패: {}", dateString);
+      throw new CustomException(ErrorCode.INVALID_REQUEST);
     }
   }
 }

--- a/RomRom-Application/src/main/java/com/romrom/application/service/AdminReviewService.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/service/AdminReviewService.java
@@ -1,0 +1,142 @@
+package com.romrom.application.service;
+
+import com.romrom.application.dto.AdminRequest;
+import com.romrom.application.dto.AdminResponse;
+import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.ErrorCode;
+import com.romrom.auth.dto.CustomUserDetails;
+import com.romrom.item.entity.postgres.TradeReview;
+import com.romrom.item.repository.postgres.TradeReviewRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관리자 후기 블라인드 관리 서비스
+ * - 후기 목록(평점/기간/블라인드 필터), 블라인드/해제 처리 (Blindable 계약 기반)
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminReviewService {
+
+  private static final DateTimeFormatter REVIEW_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  private final TradeReviewRepository tradeReviewRepository;
+
+  /**
+   * 관리자 후기 목록 조회 (평점/기간/블라인드여부 필터, 페이지네이션)
+   */
+  @Transactional(readOnly = true)
+  public AdminResponse getReviewsForAdmin(AdminRequest request) {
+    LocalDateTime startDateTime = parseStartDate(request.getStartDate());
+    LocalDateTime endDateTime = parseEndDate(request.getEndDate());
+
+    Pageable pageable = PageRequest.of(
+        request.getPageNumber(),
+        request.getPageSize(),
+        Sort.by(request.getSortDirection(), request.getSortBy())
+    );
+
+    Page<TradeReview> reviewPage = tradeReviewRepository.findReviewsForAdmin(
+        request.getTradeReviewRating(),
+        startDateTime,
+        endDateTime,
+        request.getIsBlindedFilter(),
+        pageable
+    );
+
+    log.info("관리자 후기 목록 조회: rating={}, isBlinded={}, totalElements={}",
+        request.getTradeReviewRating(), request.getIsBlindedFilter(), reviewPage.getTotalElements());
+
+    return AdminResponse.builder()
+        .reviews(reviewPage)
+        .totalCount(reviewPage.getTotalElements())
+        .totalPages(reviewPage.getTotalPages())
+        .totalElements(reviewPage.getTotalElements())
+        .currentPage(reviewPage.getNumber())
+        .build();
+  }
+
+  /**
+   * 후기 블라인드 처리 (처리자/시각 기록)
+   */
+  @Transactional
+  public AdminResponse blindReview(AdminRequest request) {
+    TradeReview tradeReview = findReviewById(request.getTradeReviewId());
+    UUID currentAdminId = getCurrentAdminId();
+
+    tradeReview.blind(request.getBlindReason(), currentAdminId);
+
+    log.info("관리자 후기 블라인드 처리: tradeReviewId={}, byAdminId={}, reason={}",
+        tradeReview.getTradeReviewId(), currentAdminId, request.getBlindReason());
+
+    return AdminResponse.builder().build();
+  }
+
+  /**
+   * 후기 블라인드 해제 (처리 정보 초기화)
+   */
+  @Transactional
+  public AdminResponse unblindReview(AdminRequest request) {
+    TradeReview tradeReview = findReviewById(request.getTradeReviewId());
+
+    tradeReview.unblind();
+
+    log.info("관리자 후기 블라인드 해제: tradeReviewId={}", tradeReview.getTradeReviewId());
+
+    return AdminResponse.builder().build();
+  }
+
+  private TradeReview findReviewById(UUID tradeReviewId) {
+    return tradeReviewRepository.findById(tradeReviewId)
+        .orElseThrow(() -> new CustomException(ErrorCode.TRADE_REVIEW_NOT_FOUND));
+  }
+
+  /**
+   * 현재 인증된 관리자(Member)의 memberId 추출
+   * - admin 은 ROLE_ADMIN Member 이므로 SecurityContext 의 principal 에서 memberId 를 얻는다
+   */
+  private UUID getCurrentAdminId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails customUserDetails)) {
+      log.warn("관리자 인증 정보를 확인할 수 없습니다. 블라인드 처리자 미기록");
+      return null;
+    }
+    return customUserDetails.getMember().getMemberId();
+  }
+
+  private LocalDateTime parseStartDate(String startDateString) {
+    LocalDate localDate = parseLocalDate(startDateString);
+    return localDate == null ? null : localDate.atStartOfDay();
+  }
+
+  private LocalDateTime parseEndDate(String endDateString) {
+    LocalDate localDate = parseLocalDate(endDateString);
+    return localDate == null ? null : localDate.atTime(LocalTime.MAX);
+  }
+
+  private LocalDate parseLocalDate(String dateString) {
+    if (dateString == null || dateString.trim().isEmpty()) {
+      return null;
+    }
+    try {
+      return LocalDate.parse(dateString.trim(), REVIEW_DATE_FORMAT);
+    } catch (Exception e) {
+      log.warn("후기 관리 날짜 파싱 실패: {}", dateString, e);
+      return null;
+    }
+  }
+}

--- a/RomRom-Application/src/main/java/com/romrom/application/service/AdminReviewService.java
+++ b/RomRom-Application/src/main/java/com/romrom/application/service/AdminReviewService.java
@@ -80,8 +80,9 @@ public class AdminReviewService {
 
     tradeReview.blind(request.getBlindReason(), currentAdminId);
 
-    log.info("관리자 후기 블라인드 처리: tradeReviewId={}, byAdminId={}, reason={}",
-        tradeReview.getTradeReviewId(), currentAdminId, request.getBlindReason());
+    // 사유 원문은 민감 정보가 포함될 수 있어 로그에 남기지 않는다 (ID 만 기록)
+    log.info("관리자 후기 블라인드 처리: tradeReviewId={}, byAdminId={}",
+        tradeReview.getTradeReviewId(), currentAdminId);
 
     return AdminResponse.builder().build();
   }
@@ -108,12 +109,13 @@ public class AdminReviewService {
   /**
    * 현재 인증된 관리자(Member)의 memberId 추출
    * - admin 은 ROLE_ADMIN Member 이므로 SecurityContext 의 principal 에서 memberId 를 얻는다
+   * - 인증 정보가 없으면 처리자 추적이 깨지므로 블라인드 처리를 진행하지 않고 인증 예외로 실패시킨다
    */
   private UUID getCurrentAdminId() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails customUserDetails)) {
-      log.warn("관리자 인증 정보를 확인할 수 없습니다. 블라인드 처리자 미기록");
-      return null;
+      log.error("관리자 인증 정보를 확인할 수 없어 블라인드 처리를 중단합니다.");
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
     }
     return customUserDetails.getMember().getMemberId();
   }
@@ -128,6 +130,9 @@ public class AdminReviewService {
     return localDate == null ? null : localDate.atTime(LocalTime.MAX);
   }
 
+  /**
+   * yyyy-MM-dd 파싱. 미입력은 null(전체 기간), 형식 오류는 INVALID_REQUEST 로 끊는다.
+   */
   private LocalDate parseLocalDate(String dateString) {
     if (dateString == null || dateString.trim().isEmpty()) {
       return null;
@@ -135,8 +140,8 @@ public class AdminReviewService {
     try {
       return LocalDate.parse(dateString.trim(), REVIEW_DATE_FORMAT);
     } catch (Exception e) {
-      log.warn("후기 관리 날짜 파싱 실패: {}", dateString, e);
-      return null;
+      log.warn("후기 관리 날짜 파싱 실패: {}", dateString);
+      throw new CustomException(ErrorCode.INVALID_REQUEST);
     }
   }
 }

--- a/RomRom-Common/src/main/java/com/romrom/common/entity/postgres/BlindInfo.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/entity/postgres/BlindInfo.java
@@ -1,0 +1,36 @@
+package com.romrom.common.entity.postgres;
+
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 관리자 블라인드(비공개) 처리 정보 공통 묶음
+ * - 운영자가 부적절한 콘텐츠를 숨기고 "누가·언제·왜" 처리했는지 추적하기 위한 4필드
+ * - @Embeddable 이므로 품은 엔티티 테이블에 컬럼으로 펼쳐진다 (별도 테이블 X)
+ * - 여러 도메인 재사용 대비해 RomRom-Common 에 위치 (이번 적용 대상은 TradeReview)
+ */
+@Embeddable
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class BlindInfo {
+
+  @lombok.Builder.Default
+  private Boolean isBlinded = false; // 블라인드 처리 여부
+
+  private String blindReason; // 블라인드 처리 사유
+
+  private UUID blindByAdminId; // 블라인드 처리한 관리자 식별자
+
+  private LocalDateTime blindDate; // 블라인드 처리 시각
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/entity/postgres/BlindInfo.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/entity/postgres/BlindInfo.java
@@ -1,5 +1,6 @@
 package com.romrom.common.entity.postgres;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -26,9 +27,11 @@ import lombok.ToString;
 public class BlindInfo {
 
   @lombok.Builder.Default
-  private Boolean isBlinded = false; // 블라인드 처리 여부
+  @Column(nullable = false)
+  private Boolean isBlinded = false; // 블라인드 처리 여부 (migration: NOT NULL DEFAULT false)
 
-  private String blindReason; // 블라인드 처리 사유
+  @Column(length = 500)
+  private String blindReason; // 블라인드 처리 사유 (migration: VARCHAR(500))
 
   private UUID blindByAdminId; // 블라인드 처리한 관리자 식별자
 

--- a/RomRom-Common/src/main/java/com/romrom/common/entity/postgres/Blindable.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/entity/postgres/Blindable.java
@@ -1,0 +1,21 @@
+package com.romrom.common.entity.postgres;
+
+import java.util.UUID;
+
+/**
+ * 관리자 블라인드 처리 계약
+ * - BlindInfo 를 품은 엔티티가 구현하여, admin 서비스가 엔티티 종류와 무관하게
+ *   동일한 흐름으로 블라인드/해제를 수행할 수 있게 한다
+ */
+public interface Blindable {
+
+  /**
+   * 블라인드 처리 (처리자/시각 기록)
+   */
+  void blind(String blindReason, UUID blindByAdminId);
+
+  /**
+   * 블라인드 해제 (처리 정보 초기화)
+   */
+  void unblind();
+}

--- a/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
@@ -160,6 +160,8 @@ public enum ErrorCode {
 
   TRADE_REVIEW_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 거래의 당사자만 후기를 작성할 수 있습니다."),
 
+  TRADE_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 후기가 존재하지 않습니다."),
+
   // CHAT
 
   CANNOT_SEND_MESSAGE_TO_DELETED_CHATROOM(HttpStatus.FORBIDDEN, "거래요청이 취소되었거나 거래완료된 상태이므로, 메시지를 보낼 수 없습니다."),

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/entity/postgres/TradeReview.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/entity/postgres/TradeReview.java
@@ -4,8 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.romrom.common.constant.TradeReviewRating;
 import com.romrom.common.constant.TradeReviewTag;
 import com.romrom.common.entity.postgres.BasePostgresEntity;
+import com.romrom.common.entity.postgres.BlindInfo;
+import com.romrom.common.entity.postgres.Blindable;
 import com.romrom.member.entity.Member;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
@@ -20,7 +23,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-public class TradeReview extends BasePostgresEntity {
+public class TradeReview extends BasePostgresEntity implements Blindable {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -45,4 +48,31 @@ public class TradeReview extends BasePostgresEntity {
 
   @Column(length = 200)
   private String reviewComment; // 한마디
+
+  // 관리자 블라인드(비공개) 처리 정보 (isBlinded/사유/처리자/시각)
+  @Embedded
+  @Builder.Default
+  private BlindInfo blindInfo = new BlindInfo();
+
+  @Override
+  public void blind(String blindReason, UUID blindByAdminId) {
+    if (this.blindInfo == null) {
+      this.blindInfo = new BlindInfo();
+    }
+    this.blindInfo.setIsBlinded(true);
+    this.blindInfo.setBlindReason(blindReason);
+    this.blindInfo.setBlindByAdminId(blindByAdminId);
+    this.blindInfo.setBlindDate(LocalDateTime.now());
+  }
+
+  @Override
+  public void unblind() {
+    if (this.blindInfo == null) {
+      this.blindInfo = new BlindInfo();
+    }
+    this.blindInfo.setIsBlinded(false);
+    this.blindInfo.setBlindReason(null);
+    this.blindInfo.setBlindByAdminId(null);
+    this.blindInfo.setBlindDate(null);
+  }
 }

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/TradeRequestHistoryRepository.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/TradeRequestHistoryRepository.java
@@ -170,4 +170,35 @@ public interface TradeRequestHistoryRepository extends JpaRepository<TradeReques
       "AND t.tradeStatus IN (com.romrom.common.constant.TradeStatus.CHATTING, " +
       "                      com.romrom.common.constant.TradeStatus.TRADE_COMPLETE_REQUESTED)")
   List<TradeRequestHistory> findActiveChattingHistoriesByItemId(@Param("itemId") UUID itemId);
+
+  /**
+   * 관리자 대시보드용: 거래 상태별 건수를 단일 group by 집계로 반환 (기간 옵션)
+   * - startDate/endDate 가 null 이면 전체 기간
+   * - 상태마다 쿼리를 분기하지 않고 한 번에 집계 (데이터 주도 카드 렌더용)
+   */
+  @Query("SELECT t.tradeStatus AS tradeStatus, COUNT(t) AS count FROM TradeRequestHistory t " +
+      "WHERE (:startDate IS NULL OR t.createdDate >= :startDate) " +
+      "AND (:endDate IS NULL OR t.createdDate <= :endDate) " +
+      "GROUP BY t.tradeStatus")
+  List<TradeStatusCountProjection> countGroupedByTradeStatus(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate);
+
+  /**
+   * 관리자 대시보드용: 최근 교환완료(TRADED) 거래 N건 (양쪽 물품/회원 페치 조인)
+   */
+  @Query("SELECT t FROM TradeRequestHistory t " +
+      "JOIN FETCH t.takeItem ti JOIN FETCH ti.member tm " +
+      "JOIN FETCH t.giveItem gi JOIN FETCH gi.member gm " +
+      "WHERE t.tradeStatus = com.romrom.common.constant.TradeStatus.TRADED " +
+      "ORDER BY t.updatedDate DESC")
+  List<TradeRequestHistory> findRecentTradedForAdmin(Pageable pageable);
+
+  /**
+   * 거래 상태별 집계 projection (status + count)
+   */
+  interface TradeStatusCountProjection {
+    TradeStatus getTradeStatus();
+    Long getCount();
+  }
 }

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/TradeReviewRepository.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/repository/postgres/TradeReviewRepository.java
@@ -1,12 +1,16 @@
 package com.romrom.item.repository.postgres;
 
+import com.romrom.common.constant.TradeReviewRating;
 import com.romrom.item.entity.postgres.TradeRequestHistory;
 import com.romrom.item.entity.postgres.TradeReview;
 import com.romrom.member.entity.Member;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TradeReviewRepository extends JpaRepository<TradeReview, UUID> {
 
@@ -16,4 +20,39 @@ public interface TradeReviewRepository extends JpaRepository<TradeReview, UUID> 
 
   // reviewedMember의 memberId로 받은 후기 페이지 조회
   Page<TradeReview> findByReviewedMember_MemberId(UUID memberId, Pageable pageable);
+
+  // 관리자 대시보드용: 기간 내 작성 후기 수 (startDate/endDate null이면 전체)
+  @Query(
+      "SELECT COUNT(r) FROM TradeReview r " +
+      "WHERE (:startDate IS NULL OR r.createdDate >= :startDate) " +
+      "AND (:endDate IS NULL OR r.createdDate <= :endDate)")
+  long countByCreatedDateBetweenNullable(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate);
+
+  /**
+   * 관리자 후기 관리용 목록 조회 (평점/기간/블라인드여부 필터, 페이지네이션)
+   * - tradeReviewRating / isBlindedFilter 가 null 이면 해당 필터 미적용
+   * - 작성자/대상자/거래를 페치 조인해 deep-link 정보 노출
+   */
+  @Query(
+      value = "SELECT r FROM TradeReview r " +
+              "JOIN FETCH r.reviewerMember " +
+              "JOIN FETCH r.reviewedMember " +
+              "JOIN FETCH r.tradeRequestHistory " +
+              "WHERE (:tradeReviewRating IS NULL OR r.tradeReviewRating = :tradeReviewRating) " +
+              "AND (:startDate IS NULL OR r.createdDate >= :startDate) " +
+              "AND (:endDate IS NULL OR r.createdDate <= :endDate) " +
+              "AND (:isBlindedFilter IS NULL OR r.blindInfo.isBlinded = :isBlindedFilter)",
+      countQuery = "SELECT COUNT(r) FROM TradeReview r " +
+              "WHERE (:tradeReviewRating IS NULL OR r.tradeReviewRating = :tradeReviewRating) " +
+              "AND (:startDate IS NULL OR r.createdDate >= :startDate) " +
+              "AND (:endDate IS NULL OR r.createdDate <= :endDate) " +
+              "AND (:isBlindedFilter IS NULL OR r.blindInfo.isBlinded = :isBlindedFilter)")
+  Page<TradeReview> findReviewsForAdmin(
+      @Param("tradeReviewRating") TradeReviewRating tradeReviewRating,
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate,
+      @Param("isBlindedFilter") Boolean isBlindedFilter,
+      Pageable pageable);
 }

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/TradeReviewService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/TradeReviewService.java
@@ -139,11 +139,12 @@ public class TradeReviewService {
   }
 
   /**
-   * 관리자에 의해 블라인드 처리된 후기는 한마디/세부태그를 안내문구로 치환한다 (자리는 남김).
+   * 관리자에 의해 블라인드 처리된 후기는 평점/한마디/세부태그를 모두 가린다 (자리는 남김).
    * - readOnly 트랜잭션이라 setter 변경이 DB 에 flush 되지 않아 원본 데이터는 보존된다 (응답 객체만 마스킹)
    */
   private void maskIfBlinded(TradeReview tradeReview) {
     if (tradeReview.getBlindInfo() != null && Boolean.TRUE.equals(tradeReview.getBlindInfo().getIsBlinded())) {
+      tradeReview.setTradeReviewRating(null);
       tradeReview.setReviewComment(BLINDED_REVIEW_NOTICE);
       tradeReview.setTradeReviewTags(java.util.Collections.emptyList());
     }

--- a/RomRom-Domain-Item/src/main/java/com/romrom/item/service/TradeReviewService.java
+++ b/RomRom-Domain-Item/src/main/java/com/romrom/item/service/TradeReviewService.java
@@ -30,6 +30,8 @@ import java.util.UUID;
 @Slf4j
 public class TradeReviewService {
 
+  private static final String BLINDED_REVIEW_NOTICE = "관리자에 의해 블라인드 처리된 후기입니다.";
+
   private final TradeReviewRepository tradeReviewRepository;
   private final TradeRequestHistoryRepository tradeRequestHistoryRepository;
   private final MemberLocationRepository memberLocationRepository;
@@ -114,6 +116,7 @@ public class TradeReviewService {
     );
 
     // reviewerMember의 @Transient 위치 정보 수동 설정 (MemberLocation 별도 조회 필요)
+    // + 관리자에 의해 블라인드 처리된 후기는 내용(태그/한마디)을 안내문구로 치환 (자리는 남김)
     tradeReviewPage.forEach(tradeReview -> {
       Member reviewerMember = tradeReview.getReviewerMember();
       Optional<MemberLocation> reviewerLocationOptional = memberLocationRepository.findByMemberMemberId(reviewerMember.getMemberId());
@@ -121,6 +124,8 @@ public class TradeReviewService {
         reviewerMember.setLatitude(reviewerLocation.getLatitude());
         reviewerMember.setLongitude(reviewerLocation.getLongitude());
       });
+
+      maskIfBlinded(tradeReview);
     });
 
     return TradeResponse.builder()
@@ -131,5 +136,16 @@ public class TradeReviewService {
   private TradeRequestHistory findTradeRequestHistoryById(UUID tradeRequestHistoryId) {
     return tradeRequestHistoryRepository.findByTradeRequestHistoryIdWithItems(tradeRequestHistoryId)
         .orElseThrow(() -> new CustomException(ErrorCode.TRADE_REQUEST_NOT_FOUND));
+  }
+
+  /**
+   * 관리자에 의해 블라인드 처리된 후기는 한마디/세부태그를 안내문구로 치환한다 (자리는 남김).
+   * - readOnly 트랜잭션이라 setter 변경이 DB 에 flush 되지 않아 원본 데이터는 보존된다 (응답 객체만 마스킹)
+   */
+  private void maskIfBlinded(TradeReview tradeReview) {
+    if (tradeReview.getBlindInfo() != null && Boolean.TRUE.equals(tradeReview.getBlindInfo().getIsBlinded())) {
+      tradeReview.setReviewComment(BLINDED_REVIEW_NOTICE);
+      tradeReview.setTradeReviewTags(java.util.Collections.emptyList());
+    }
   }
 }

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AdminApiController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AdminApiController.java
@@ -5,9 +5,11 @@ import com.romrom.application.dto.AdminResponse;
 import com.romrom.application.service.AdminAlertConfigService;
 import com.romrom.application.service.AdminAnnouncementService;
 import com.romrom.application.service.AdminAuthService;
+import com.romrom.application.service.AdminDashboardService;
 import com.romrom.application.service.AdminItemService;
 import com.romrom.application.service.AdminMemberService;
 import com.romrom.application.service.AdminReportService;
+import com.romrom.application.service.AdminReviewService;
 import com.romrom.application.service.AdminTradeService;
 import com.romrom.application.service.SystemConfigService;
 import com.romrom.item.service.ItemService;
@@ -42,6 +44,8 @@ public class AdminApiController {
     private final AdminAnnouncementService adminAnnouncementService;
     private final SystemConfigService systemConfigService;
     private final AdminAlertConfigService adminAlertConfigService;
+    private final AdminDashboardService adminDashboardService;
+    private final AdminReviewService adminReviewService;
 
     @Value("${server.ssl.enabled:false}")
     private boolean sslEnabled;
@@ -108,15 +112,39 @@ public class AdminApiController {
 
     // ==================== Dashboard ====================
 
+    @ApiChangeLogs({
+        @ApiChangeLog(date = "2026.06.04", author = Author.SUHSAECHAN, issueNumber = 714, description = "대시보드 통계에 거래 상태별 카운트(tradeStatusCounts, 데이터 주도) + 신규 후기 카운트(newReviewCount) 추가, startDate/endDate 기간 필터 지원"),
+    })
+    @Operation(
+        summary = "관리자 대시보드 통계 조회",
+        description = """
+        ## 인증: **ROLE_ADMIN**
+
+        ## 요청 파라미터 (multipart/form-data, 모두 선택)
+        - **`startDate`** (String): 기간 시작 (yyyy-MM-dd). 없으면 전체 누적
+        - **`endDate`** (String): 기간 종료 (yyyy-MM-dd, 해당 일자 23:59:59 까지 포함)
+
+        ## 반환값 (AdminResponse.dashboardStats)
+        - **`totalMembers`**: 전체 활성 회원 수 (기간 무관 현재값)
+        - **`totalItems`**: 전체 활성 물품 수 (기간 무관 현재값)
+        - **`ongoingTrades`**: 진행중 거래 건수 (기간 무관 현재값)
+        - **`pendingReports`**: 미처리 신고 건수 (기간 무관 현재값)
+        - **`tradeStatusCounts`**: 거래 상태별 건수 Map (모든 TradeStatus 키 포함, 0건도 노출). 기간 필터 적용 시 해당 기간 집계
+        - **`newReviewCount`**: 신규 후기 건수. 기간 필터 적용 시 해당 기간 작성 후기 수
+        """
+    )
     @PostMapping(value = "/dashboard/stats", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @LogMonitor
     public ResponseEntity<AdminResponse> getDashboardStats(@ModelAttribute AdminRequest request) {
+        AdminResponse.AdminDashboardStats tradeStatusStats = adminDashboardService.getTradeStatusStats(request);
         return ResponseEntity.ok(AdminResponse.builder()
             .dashboardStats(AdminResponse.AdminDashboardStats.builder()
                 .totalMembers(memberService.countActiveMembers())
                 .totalItems(itemService.countActiveItems())
                 .ongoingTrades(itemService.countOngoingTrades())
                 .pendingReports(adminReportService.countPendingReports())
+                .tradeStatusCounts(tradeStatusStats.getTradeStatusCounts())
+                .newReviewCount(tradeStatusStats.getNewReviewCount())
                 .build())
             .build());
     }
@@ -125,6 +153,24 @@ public class AdminApiController {
     @LogMonitor
     public ResponseEntity<AdminResponse> getRecentMembers(@ModelAttribute AdminRequest request) {
         return ResponseEntity.ok(adminMemberService.getRecentMembersForAdmin(8));
+    }
+
+    @ApiChangeLogs({
+        @ApiChangeLog(date = "2026.06.04", author = Author.SUHSAECHAN, issueNumber = 714, description = "대시보드 최근 교환완료(TRADED) 거래 조회 API 추가"),
+    })
+    @Operation(
+        summary = "관리자 대시보드 최근 교환완료 거래 조회",
+        description = """
+        ## 인증: **ROLE_ADMIN**
+
+        ## 반환값 (AdminResponse.recentTrades)
+        - 최근 교환완료(TRADED) 거래 최신 8건 (takeItem/giveItem 및 각 소유 회원 정보 포함, updatedDate 내림차순)
+        """
+    )
+    @PostMapping(value = "/dashboard/recent-trades", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @LogMonitor
+    public ResponseEntity<AdminResponse> getRecentTrades(@ModelAttribute AdminRequest request) {
+        return ResponseEntity.ok(adminDashboardService.getRecentTrades(8));
     }
 
     @PostMapping(value = "/dashboard/recent-items", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -499,6 +545,83 @@ public class AdminApiController {
     @LogMonitor
     public ResponseEntity<AdminResponse> getReportStats(@ModelAttribute AdminRequest request) {
         return ResponseEntity.ok(adminReportService.getStats());
+    }
+
+    // ==================== Reviews ====================
+
+    @ApiChangeLogs({
+        @ApiChangeLog(date = "2026.06.04", author = Author.SUHSAECHAN, issueNumber = 771, description = "관리자 후기 목록 조회 API 추가 (평점/기간/블라인드여부 필터)"),
+    })
+    @Operation(
+        summary = "관리자 후기 목록 조회",
+        description = """
+        ## 인증: **ROLE_ADMIN**
+
+        ## 요청 파라미터 (multipart/form-data, 모두 선택)
+        - **`tradeReviewRating`** (TradeReviewRating): 평점 필터 (BAD/GOOD/GREAT, 미입력=전체)
+        - **`isBlindedFilter`** (Boolean): 블라인드 여부 필터 (true=블라인드만, false=정상만, 미입력=전체)
+        - **`startDate`** / **`endDate`** (String, yyyy-MM-dd): 작성일 기간 필터
+        - **`pageNumber`** / **`pageSize`** / **`sortBy`** / **`sortDirection`**: 페이지네이션
+
+        ## 반환값 (AdminResponse)
+        - **`reviews`**: 페이지네이션된 후기 목록 (작성자/대상자/거래 + blindInfo 포함)
+        - **`totalCount`** / **`totalPages`** / **`totalElements`** / **`currentPage`**: 페이지 정보
+        """
+    )
+    @PostMapping(value = "/reviews/list", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @LogMonitor
+    public ResponseEntity<AdminResponse> getReviews(@ModelAttribute AdminRequest request) {
+        return ResponseEntity.ok(adminReviewService.getReviewsForAdmin(request));
+    }
+
+    @ApiChangeLogs({
+        @ApiChangeLog(date = "2026.06.04", author = Author.SUHSAECHAN, issueNumber = 771, description = "관리자 후기 블라인드 처리 API 추가 (처리자/시각 기록)"),
+    })
+    @Operation(
+        summary = "관리자 후기 블라인드 처리",
+        description = """
+        ## 인증: **ROLE_ADMIN**
+
+        ## 요청 파라미터 (multipart/form-data)
+        - **`tradeReviewId`** (UUID, 필수): 블라인드 처리할 후기 ID
+        - **`blindReason`** (String, 선택): 블라인드 사유
+
+        ## 동작 설명
+        - 실데이터 삭제 없이 일반 사용자 조회에서 후기 내용을 "관리자에 의해 블라인드 처리된 후기입니다"로 치환합니다.
+        - 처리한 관리자(blindByAdminId)와 처리 시각(blindDate)을 기록합니다.
+
+        ## 에러코드
+        - TRADE_REVIEW_NOT_FOUND (404): 해당 후기가 존재하지 않음
+        """
+    )
+    @PostMapping(value = "/reviews/blind", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @LogMonitor
+    public ResponseEntity<AdminResponse> blindReview(@ModelAttribute AdminRequest request) {
+        return ResponseEntity.ok(adminReviewService.blindReview(request));
+    }
+
+    @ApiChangeLogs({
+        @ApiChangeLog(date = "2026.06.04", author = Author.SUHSAECHAN, issueNumber = 771, description = "관리자 후기 블라인드 해제 API 추가"),
+    })
+    @Operation(
+        summary = "관리자 후기 블라인드 해제",
+        description = """
+        ## 인증: **ROLE_ADMIN**
+
+        ## 요청 파라미터 (multipart/form-data)
+        - **`tradeReviewId`** (UUID, 필수): 블라인드를 해제할 후기 ID
+
+        ## 동작 설명
+        - 블라인드 처리 정보(isBlinded/사유/처리자/시각)를 초기화하여 후기를 다시 노출합니다.
+
+        ## 에러코드
+        - TRADE_REVIEW_NOT_FOUND (404): 해당 후기가 존재하지 않음
+        """
+    )
+    @PostMapping(value = "/reviews/unblind", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @LogMonitor
+    public ResponseEntity<AdminResponse> unblindReview(@ModelAttribute AdminRequest request) {
+        return ResponseEntity.ok(adminReviewService.unblindReview(request));
     }
 
     // ==================== Announcements ====================

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/view/AdminPageController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/view/AdminPageController.java
@@ -121,6 +121,14 @@ public class AdminPageController {
         return "admin/trades";
     }
 
+    @GetMapping("/reviews")
+    @LogMonitor
+    public String reviews(Model model) {
+        model.addAttribute("pageTitle", "후기 관리");
+        model.addAttribute("currentMenu", "reviews");
+        return "admin/reviews";
+    }
+
     @GetMapping("/reports")
     @LogMonitor
     public String reports(Model model) {

--- a/RomRom-Web/src/main/resources/db/migration/V1_4_62__add_trade_review_blind_columns.sql
+++ b/RomRom-Web/src/main/resources/db/migration/V1_4_62__add_trade_review_blind_columns.sql
@@ -1,0 +1,42 @@
+-- 거래 후기(trade_review) 관리자 블라인드 처리 컬럼 추가
+-- #771: BlindInfo(@Embeddable) - isBlinded/blindReason/blindByAdminId/blindDate
+-- V1_4_60(item admin hidden) 동일 패턴: 컬럼별 테이블 존재 + 컬럼 부재 가드 + 멱등 블록
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_review'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'is_blinded'
+    ) THEN
+        ALTER TABLE trade_review ADD COLUMN is_blinded BOOLEAN NOT NULL DEFAULT false;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_review'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_reason'
+    ) THEN
+        ALTER TABLE trade_review ADD COLUMN blind_reason VARCHAR(500);
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_review'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_by_admin_id'
+    ) THEN
+        ALTER TABLE trade_review ADD COLUMN blind_by_admin_id UUID;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_review'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_date'
+    ) THEN
+        ALTER TABLE trade_review ADD COLUMN blind_date TIMESTAMP;
+    END IF;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING '오류 발생: %', SQLERRM;
+END $$;

--- a/RomRom-Web/src/main/resources/db/migration/V1_4_62__add_trade_review_blind_columns.sql
+++ b/RomRom-Web/src/main/resources/db/migration/V1_4_62__add_trade_review_blind_columns.sql
@@ -9,7 +9,7 @@ BEGIN
     ) AND NOT EXISTS (
         SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'is_blinded'
     ) THEN
-        ALTER TABLE trade_review ADD COLUMN is_blinded BOOLEAN NOT NULL DEFAULT false;
+        ALTER TABLE IF EXISTS trade_review ADD COLUMN is_blinded BOOLEAN NOT NULL DEFAULT false;
     END IF;
 
     IF EXISTS (
@@ -17,7 +17,7 @@ BEGIN
     ) AND NOT EXISTS (
         SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_reason'
     ) THEN
-        ALTER TABLE trade_review ADD COLUMN blind_reason VARCHAR(500);
+        ALTER TABLE IF EXISTS trade_review ADD COLUMN blind_reason VARCHAR(500);
     END IF;
 
     IF EXISTS (
@@ -25,7 +25,7 @@ BEGIN
     ) AND NOT EXISTS (
         SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_by_admin_id'
     ) THEN
-        ALTER TABLE trade_review ADD COLUMN blind_by_admin_id UUID;
+        ALTER TABLE IF EXISTS trade_review ADD COLUMN blind_by_admin_id UUID;
     END IF;
 
     IF EXISTS (
@@ -33,7 +33,7 @@ BEGIN
     ) AND NOT EXISTS (
         SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_date'
     ) THEN
-        ALTER TABLE trade_review ADD COLUMN blind_date TIMESTAMP;
+        ALTER TABLE IF EXISTS trade_review ADD COLUMN blind_date TIMESTAMP;
     END IF;
 
 EXCEPTION

--- a/RomRom-Web/src/main/resources/templates/admin/dashboard.html
+++ b/RomRom-Web/src/main/resources/templates/admin/dashboard.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <!-- 통계 카드 -->
+    <!-- 상단 고정 통계 카드 (기간 무관 현재값) -->
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <!-- 전체 회원 -->
         <div class="stat bg-base-100 rounded-box shadow">
@@ -50,8 +50,37 @@
         </div>
     </div>
 
+    <!-- 기간 필터 바 -->
+    <div class="card bg-base-100 shadow mb-4">
+        <div class="card-body py-3">
+            <div class="flex flex-wrap items-center gap-2">
+                <span class="font-semibold text-sm mr-1">
+                    <i data-lucide="calendar-range" class="size-4 inline"></i> 기간
+                </span>
+                <div class="join" id="periodPresetGroup">
+                    <button type="button" class="btn btn-sm join-item period-preset btn-active" data-period="all">전체</button>
+                    <button type="button" class="btn btn-sm join-item period-preset" data-period="today">오늘</button>
+                    <button type="button" class="btn btn-sm join-item period-preset" data-period="7">7일</button>
+                    <button type="button" class="btn btn-sm join-item period-preset" data-period="30">30일</button>
+                </div>
+                <input type="date" id="customStartDate" class="input input-bordered input-sm w-auto"/>
+                <span class="text-base-content/50">~</span>
+                <input type="date" id="customEndDate" class="input input-bordered input-sm w-auto"/>
+                <button type="button" id="applyCustomPeriod" class="btn btn-sm btn-primary">조회</button>
+                <span id="periodLabel" class="text-xs text-base-content/60 ml-auto">전체 누적</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- 거래 상태별 카드 (데이터 주도 자동 렌더) + 신규 후기 카드 -->
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6" id="tradeStatusCards">
+        <div class="col-span-full text-center py-4">
+            <span class="loading loading-spinner loading-sm"></span> 불러오는 중...
+        </div>
+    </div>
+
     <!-- 최근 활동 섹션 -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
         <!-- 최근 가입 회원 -->
         <div class="card bg-base-100 shadow">
             <div class="card-body">
@@ -117,23 +146,161 @@
             </div>
         </div>
     </div>
+
+    <!-- 최근 교환완료 거래 -->
+    <div class="card bg-base-100 shadow">
+        <div class="card-body">
+            <h2 class="card-title text-base">
+                <i data-lucide="check-circle-2" class="size-5 text-success"></i>
+                최근 교환완료 거래
+                <span id="recentTradesBadge" class="badge badge-success badge-sm">로딩중</span>
+            </h2>
+            <div class="overflow-x-auto">
+                <table class="table table-sm" id="recentTradesTable">
+                    <thead>
+                    <tr>
+                        <th>거래 물품</th>
+                        <th>거래 회원</th>
+                        <th>완료일</th>
+                    </tr>
+                    </thead>
+                    <tbody id="recentTradesBody">
+                    <tr>
+                        <td colspan="3" class="text-center">
+                            <span class="loading loading-spinner loading-sm"></span> 불러오는 중...
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="card-actions justify-end mt-2">
+                <a th:href="@{/admin/trades}" class="btn btn-ghost btn-sm">전체 보기</a>
+            </div>
+        </div>
+    </div>
 </div>
 
 <th:block layout:fragment="js">
     <script>
-        // 대시보드 데이터 로드
-        function loadDashboardData() {
-            loadRecentMembers();
-            loadRecentItems();
+        // 거래 상태별 카드 메타 (라벨/색상/아이콘) — TradeStatus enum 키 기준
+        const TRADE_STATUS_META = {
+            PENDING:                   { label: '대기',       color: 'text-base-content/70', icon: 'clock' },
+            CHATTING:                  { label: '채팅중',     color: 'text-info',            icon: 'message-circle' },
+            TRADE_COMPLETE_REQUESTED:  { label: '완료요청',   color: 'text-warning',         icon: 'hourglass' },
+            TRADED:                    { label: '거래완료',   color: 'text-success',         icon: 'check-circle-2' },
+            CANCELED:                  { label: '취소',       color: 'text-error',           icon: 'x-circle' }
+        };
+
+        // 현재 선택된 기간 (startDate/endDate, 빈 문자열이면 전체)
+        let currentPeriod = { startDate: '', endDate: '' };
+
+        function pad2(n) { return String(n).padStart(2, '0'); }
+        function formatDate(d) {
+            return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
         }
 
+        // preset(today/7/30/all) → startDate/endDate 계산
+        function periodFromPreset(preset) {
+            if (preset === 'all') return { startDate: '', endDate: '', label: '전체 누적' };
+            const today = new Date();
+            const endDate = formatDate(today);
+            if (preset === 'today') {
+                return { startDate: endDate, endDate: endDate, label: `오늘 (${endDate})` };
+            }
+            const start = new Date();
+            start.setDate(start.getDate() - (parseInt(preset, 10) - 1));
+            const startDate = formatDate(start);
+            return { startDate, endDate, label: `${startDate} ~ ${endDate}` };
+        }
+
+        function buildStatsFormData() {
+            const formData = new FormData();
+            if (currentPeriod.startDate) formData.append('startDate', currentPeriod.startDate);
+            if (currentPeriod.endDate) formData.append('endDate', currentPeriod.endDate);
+            return formData;
+        }
+
+        // 통계 로드 (거래 상태별 카드 + 후기 카드)
+        function loadTradeStatusStats() {
+            const container = document.getElementById('tradeStatusCards');
+            container.innerHTML = '<div class="col-span-full text-center py-4"><span class="loading loading-spinner loading-sm"></span> 불러오는 중...</div>';
+
+            fetch('/api/admin/dashboard/stats', { method: 'POST', body: buildStatsFormData(), credentials: 'same-origin' })
+                .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+                .then(data => renderTradeStatusCards(data.dashboardStats))
+                .catch(e => {
+                    console.error('대시보드 통계 로드 실패:', e);
+                    container.innerHTML = '<div class="col-span-full text-center py-4 text-error">통계 로드 실패</div>';
+                });
+        }
+
+        function renderTradeStatusCards(stats) {
+            const container = document.getElementById('tradeStatusCards');
+            if (!stats) { container.innerHTML = '<div class="col-span-full text-center py-4 text-base-content/60">데이터 없음</div>'; return; }
+
+            const tradeStatusCounts = stats.tradeStatusCounts || {};
+            // TRADE_STATUS_META 순서대로 카드 렌더 (응답에 없는 상태는 0). 카드 클릭 → 해당 상태 거래목록 드릴다운
+            let html = Object.keys(TRADE_STATUS_META).map(statusKey => {
+                const meta = TRADE_STATUS_META[statusKey];
+                const count = tradeStatusCounts[statusKey] != null ? tradeStatusCounts[statusKey] : 0;
+                const drillUrl = `/admin/trades?tradeStatus=${statusKey}`
+                    + (currentPeriod.startDate ? `&startDate=${currentPeriod.startDate}` : '')
+                    + (currentPeriod.endDate ? `&endDate=${currentPeriod.endDate}` : '');
+                return `
+                <div class="stat bg-base-100 rounded-box shadow cursor-pointer hover:bg-base-200 transition p-4"
+                     onclick="location.href='${drillUrl}'">
+                    <div class="stat-title text-xs flex items-center gap-1">
+                        <i data-lucide="${meta.icon}" class="size-4 ${meta.color}"></i>${meta.label}
+                    </div>
+                    <div class="stat-value text-2xl ${meta.color}">${count}</div>
+                </div>`;
+            }).join('');
+
+            // 신규 후기 카드 (읽기 전용, 클릭 없음)
+            const newReviewCount = stats.newReviewCount != null ? stats.newReviewCount : 0;
+            html += `
+                <div class="stat bg-base-100 rounded-box shadow p-4">
+                    <div class="stat-title text-xs flex items-center gap-1">
+                        <i data-lucide="star" class="size-4 text-secondary"></i>신규 후기
+                    </div>
+                    <div class="stat-value text-2xl text-secondary">${newReviewCount}</div>
+                </div>`;
+
+            container.innerHTML = html;
+            lucide.createIcons();
+        }
+
+        // 기간 프리셋 버튼
+        document.querySelectorAll('.period-preset').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.period-preset').forEach(b => b.classList.remove('btn-active'));
+                btn.classList.add('btn-active');
+                document.getElementById('customStartDate').value = '';
+                document.getElementById('customEndDate').value = '';
+                const period = periodFromPreset(btn.dataset.period);
+                currentPeriod = { startDate: period.startDate, endDate: period.endDate };
+                document.getElementById('periodLabel').textContent = period.label;
+                loadTradeStatusStats();
+            });
+        });
+
+        // 직접 기간 조회
+        document.getElementById('applyCustomPeriod').addEventListener('click', () => {
+            const startDate = document.getElementById('customStartDate').value;
+            const endDate = document.getElementById('customEndDate').value;
+            if (!startDate && !endDate) { alert('시작일 또는 종료일을 선택하세요.'); return; }
+            document.querySelectorAll('.period-preset').forEach(b => b.classList.remove('btn-active'));
+            currentPeriod = { startDate, endDate };
+            document.getElementById('periodLabel').textContent = `${startDate || '처음'} ~ ${endDate || '오늘'}`;
+            loadTradeStatusStats();
+        });
+
+        // 최근 가입 회원
         function loadRecentMembers() {
             adminFetch.post('/api/admin/dashboard/recent-members')
                 .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
                 .then(data => {
-                    if (data.members && data.members.content) {
-                        renderRecentMembers(data.members.content);
-                    }
+                    if (data.members && data.members.content) renderRecentMembers(data.members.content);
                 })
                 .catch(e => console.error('최근 회원 로드 실패:', e));
         }
@@ -142,36 +309,37 @@
             adminFetch.post('/api/admin/dashboard/recent-items')
                 .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
                 .then(data => {
-                    if (data.items && data.items.content) {
-                        renderRecentItems(data.items.content);
-                    }
+                    if (data.items && data.items.content) renderRecentItems(data.items.content);
                 })
                 .catch(e => console.error('최근 물품 로드 실패:', e));
+        }
+
+        // 최근 교환완료 거래
+        function loadRecentTrades() {
+            adminFetch.post('/api/admin/dashboard/recent-trades')
+                .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+                .then(data => renderRecentTrades(data.recentTrades || []))
+                .catch(e => console.error('최근 교환완료 거래 로드 실패:', e));
         }
 
         function renderRecentMembers(members) {
             const tbody = document.getElementById('recentMembersBody');
             const badge = document.getElementById('membersBadge');
             if (!tbody) return;
-
             if (!members || members.length === 0) {
                 tbody.innerHTML = '<tr><td colspan="3" class="text-center text-base-content/60">등록된 회원이 없습니다.</td></tr>';
                 if (badge) badge.textContent = '0명';
                 return;
             }
-
             if (badge) badge.textContent = `${members.length}명`;
-
             tbody.innerHTML = members.map(m => {
-                // profileUrl이 없거나 빈 문자열이면 기본 이미지 사용
                 const profileSrc = (m.profileUrl && m.profileUrl.trim()) ? escapeHtml(m.profileUrl) : '/assets/img/default-150x150.png';
                 return `
                 <tr class="cursor-pointer hover" onclick="location.href='/admin/members/${m.memberId}'">
                     <td>
                         <div class="avatar">
                             <div class="w-8 rounded-full">
-                                <img src="${profileSrc}" alt="프로필"
-                                     onerror="this.src='/assets/img/default-150x150.png'"/>
+                                <img src="${profileSrc}" alt="프로필" onerror="this.src='/assets/img/default-150x150.png'"/>
                             </div>
                         </div>
                     </td>
@@ -179,49 +347,68 @@
                     <td class="text-base-content/60 text-sm">${TimeUtils.getRelativeTime(m.createdDate)}</td>
                 </tr>`;
             }).join('');
-
             lucide.createIcons();
         }
 
         function renderRecentItems(items) {
             const tbody = document.getElementById('recentItemsBody');
             if (!tbody) return;
-
             if (!items || items.length === 0) {
                 tbody.innerHTML = '<tr><td colspan="5" class="text-center text-base-content/60">등록된 물품이 없습니다.</td></tr>';
                 return;
             }
-
             tbody.innerHTML = items.map(item => {
-                // itemImages 배열 첫 번째 항목의 imageUrl 사용, 없으면 기본 이미지
                 const mainImageUrl = (item.itemImages && item.itemImages.length > 0 && item.itemImages[0].imageUrl)
-                    ? escapeHtml(item.itemImages[0].imageUrl)
-                    : '/assets/img/default-150x150.png';
-                // 판매자 닉네임: member.nickname 경로 대응
+                    ? escapeHtml(item.itemImages[0].imageUrl) : '/assets/img/default-150x150.png';
                 const sellerNickname = item.member?.nickname || item.sellerNickname || '익명';
                 return `
                 <tr class="cursor-pointer hover" onclick="location.href='/admin/items/${item.itemId}'">
                     <td>
                         <div class="avatar">
                             <div class="w-10 rounded">
-                                <img src="${mainImageUrl}" alt="물품"
-                                     onerror="this.src='/assets/img/default-150x150.png'"/>
+                                <img src="${mainImageUrl}" alt="물품" onerror="this.src='/assets/img/default-150x150.png'"/>
                             </div>
                         </div>
                     </td>
-                    <td>
-                        <div class="font-medium text-sm truncate max-w-32">${escapeHtml(item.itemName) || '-'}</div>
-                    </td>
+                    <td><div class="font-medium text-sm truncate max-w-32">${escapeHtml(item.itemName) || '-'}</div></td>
                     <td class="text-sm">${NumberUtils.formatPrice(item.price)}</td>
                     <td class="text-sm text-base-content/60">${escapeHtml(sellerNickname)}</td>
                     <td class="text-sm text-base-content/60">${TimeUtils.getRelativeTime(item.createdDate)}</td>
                 </tr>`;
             }).join('');
-
             lucide.createIcons();
         }
 
-        loadDashboardData();
+        function renderRecentTrades(trades) {
+            const tbody = document.getElementById('recentTradesBody');
+            const badge = document.getElementById('recentTradesBadge');
+            if (!tbody) return;
+            if (!trades || trades.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="3" class="text-center text-base-content/60">교환완료된 거래가 없습니다.</td></tr>';
+                if (badge) badge.textContent = '0건';
+                return;
+            }
+            if (badge) badge.textContent = `${trades.length}건`;
+            tbody.innerHTML = trades.map(t => {
+                const takeName = t.takeItem?.itemName || '-';
+                const giveName = t.giveItem?.itemName || '-';
+                const takeMember = t.takeItem?.member?.nickname || '익명';
+                const giveMember = t.giveItem?.member?.nickname || '익명';
+                return `
+                <tr class="cursor-pointer hover" onclick="location.href='/admin/trades?tradeRequestHistoryId=${t.tradeRequestHistoryId}'">
+                    <td class="text-sm">${escapeHtml(takeName)} <span class="text-base-content/40">↔</span> ${escapeHtml(giveName)}</td>
+                    <td class="text-sm text-base-content/70">${escapeHtml(takeMember)} <span class="text-base-content/40">↔</span> ${escapeHtml(giveMember)}</td>
+                    <td class="text-sm text-base-content/60">${TimeUtils.getRelativeTime(t.updatedDate)}</td>
+                </tr>`;
+            }).join('');
+            lucide.createIcons();
+        }
+
+        // 초기 로드
+        loadTradeStatusStats();
+        loadRecentMembers();
+        loadRecentItems();
+        loadRecentTrades();
     </script>
 </th:block>
 </body>

--- a/RomRom-Web/src/main/resources/templates/admin/layout.html
+++ b/RomRom-Web/src/main/resources/templates/admin/layout.html
@@ -127,6 +127,12 @@
                     </a>
                 </li>
                 <li>
+                    <a th:href="@{/admin/reviews}" th:classappend="${currentMenu == 'reviews'} ? 'active'">
+                        <i data-lucide="star" class="size-5"></i>
+                        후기 관리
+                    </a>
+                </li>
+                <li>
                     <a th:href="@{/admin/reports}" th:classappend="${currentMenu == 'reports'} ? 'active'">
                         <i data-lucide="flag" class="size-5"></i>
                         신고 관리

--- a/RomRom-Web/src/main/resources/templates/admin/reviews.html
+++ b/RomRom-Web/src/main/resources/templates/admin/reviews.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{admin/layout}">
+<head>
+    <title layout:fragment="title">후기 관리</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <!-- 필터 바 -->
+    <div class="card bg-base-100 shadow mb-4">
+        <div class="card-body py-3">
+            <div class="flex flex-wrap items-end gap-3">
+                <div>
+                    <label class="label label-text text-xs py-0">평점</label>
+                    <select id="filterRating" class="select select-bordered select-sm">
+                        <option value="">전체</option>
+                        <option value="GREAT">최고예요</option>
+                        <option value="GOOD">좋아요</option>
+                        <option value="BAD">별로예요</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="label label-text text-xs py-0">블라인드</label>
+                    <select id="filterBlinded" class="select select-bordered select-sm">
+                        <option value="">전체</option>
+                        <option value="true">블라인드만</option>
+                        <option value="false">정상만</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="label label-text text-xs py-0">시작일</label>
+                    <input type="date" id="filterStartDate" class="input input-bordered input-sm"/>
+                </div>
+                <div>
+                    <label class="label label-text text-xs py-0">종료일</label>
+                    <input type="date" id="filterEndDate" class="input input-bordered input-sm"/>
+                </div>
+                <button type="button" id="applyFilter" class="btn btn-sm btn-primary">
+                    <i data-lucide="search" class="size-4"></i> 조회
+                </button>
+                <span id="reviewsTotal" class="text-xs text-base-content/60 ml-auto">총 0건</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- 목록 -->
+    <div class="card bg-base-100 shadow">
+        <div class="card-body">
+            <div class="overflow-x-auto">
+                <table class="table table-sm" id="reviewsTable">
+                    <thead>
+                    <tr>
+                        <th>평점</th>
+                        <th>한마디</th>
+                        <th>작성자 → 대상자</th>
+                        <th>작성일</th>
+                        <th>상태</th>
+                        <th>처리</th>
+                    </tr>
+                    </thead>
+                    <tbody id="reviewsBody">
+                    <tr>
+                        <td colspan="6" class="text-center">
+                            <span class="loading loading-spinner loading-sm"></span> 불러오는 중...
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <!-- 페이지네이션 -->
+            <div class="flex justify-center mt-4">
+                <div class="join" id="reviewsPagination"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 블라인드 처리 모달 -->
+<dialog id="blindModal" class="modal">
+    <div class="modal-box">
+        <h3 class="font-bold text-lg">후기 블라인드 처리</h3>
+        <p class="py-2 text-sm text-base-content/70">
+            이 후기를 블라인드 처리하면 일반 사용자에게 "관리자에 의해 블라인드 처리된 후기입니다"로 표시됩니다.
+        </p>
+        <input type="hidden" id="blindTargetReviewId"/>
+        <label class="label label-text text-sm">블라인드 사유</label>
+        <textarea id="blindReasonInput" class="textarea textarea-bordered w-full" rows="3"
+                  placeholder="예: 욕설/허위/명예훼손 등"></textarea>
+        <div class="modal-action">
+            <button type="button" id="confirmBlind" class="btn btn-error btn-sm">블라인드 처리</button>
+            <form method="dialog"><button class="btn btn-sm">취소</button></form>
+        </div>
+    </div>
+    <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+<th:block layout:fragment="js">
+    <script>
+        const REVIEW_RATING_LABEL = { GREAT: '최고예요', GOOD: '좋아요', BAD: '별로예요' };
+        const REVIEW_RATING_BADGE = { GREAT: 'badge-success', GOOD: 'badge-info', BAD: 'badge-error' };
+
+        let currentReviewPage = 0;
+
+        function buildReviewFormData(pageNumber) {
+            const formData = new FormData();
+            const rating = document.getElementById('filterRating').value;
+            const blinded = document.getElementById('filterBlinded').value;
+            const startDate = document.getElementById('filterStartDate').value;
+            const endDate = document.getElementById('filterEndDate').value;
+            if (rating) formData.append('tradeReviewRating', rating);
+            if (blinded) formData.append('isBlindedFilter', blinded);
+            if (startDate) formData.append('startDate', startDate);
+            if (endDate) formData.append('endDate', endDate);
+            formData.append('pageNumber', pageNumber);
+            formData.append('pageSize', 20);
+            return formData;
+        }
+
+        function loadReviews(pageNumber) {
+            currentReviewPage = pageNumber;
+            const tbody = document.getElementById('reviewsBody');
+            tbody.innerHTML = '<tr><td colspan="6" class="text-center"><span class="loading loading-spinner loading-sm"></span> 불러오는 중...</td></tr>';
+
+            fetch('/api/admin/reviews/list', { method: 'POST', body: buildReviewFormData(pageNumber), credentials: 'same-origin' })
+                .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+                .then(data => renderReviews(data))
+                .catch(e => {
+                    console.error('후기 목록 로드 실패:', e);
+                    tbody.innerHTML = '<tr><td colspan="6" class="text-center text-error">로드 실패</td></tr>';
+                });
+        }
+
+        function renderReviews(data) {
+            const tbody = document.getElementById('reviewsBody');
+            const reviews = (data.reviews && data.reviews.content) ? data.reviews.content : [];
+            document.getElementById('reviewsTotal').textContent = `총 ${data.totalElements != null ? data.totalElements : 0}건`;
+
+            if (reviews.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="6" class="text-center text-base-content/60">후기가 없습니다.</td></tr>';
+                document.getElementById('reviewsPagination').innerHTML = '';
+                return;
+            }
+
+            tbody.innerHTML = reviews.map(review => {
+                const isBlinded = review.blindInfo && review.blindInfo.isBlinded === true;
+                const ratingKey = review.tradeReviewRating;
+                const ratingBadge = `<span class="badge badge-sm ${REVIEW_RATING_BADGE[ratingKey] || ''}">${REVIEW_RATING_LABEL[ratingKey] || ratingKey || '-'}</span>`;
+                const reviewer = review.reviewerMember?.nickname || '익명';
+                const reviewed = review.reviewedMember?.nickname || '익명';
+                const comment = isBlinded
+                    ? '<span class="text-base-content/40 italic">🔒 블라인드 처리됨</span>'
+                    : escapeHtml(review.reviewComment || '-');
+
+                let statusCell, actionCell;
+                if (isBlinded) {
+                    const reason = escapeHtml(review.blindInfo.blindReason || '-');
+                    const blindDate = review.blindInfo.blindDate ? TimeUtils.getRelativeTime(review.blindInfo.blindDate) : '-';
+                    statusCell = `<span class="badge badge-error badge-sm">블라인드</span>
+                        <div class="text-xs text-base-content/50 mt-1">사유: ${reason}<br/>${blindDate}</div>`;
+                    actionCell = `<button class="btn btn-xs btn-outline" onclick="unblindReview('${review.tradeReviewId}')">해제</button>`;
+                } else {
+                    statusCell = '<span class="badge badge-ghost badge-sm">정상</span>';
+                    actionCell = `<button class="btn btn-xs btn-error" onclick="openBlindModal('${review.tradeReviewId}')">블라인드</button>`;
+                }
+
+                return `
+                <tr>
+                    <td>${ratingBadge}</td>
+                    <td class="max-w-xs truncate">${comment}</td>
+                    <td class="text-sm">${escapeHtml(reviewer)} <span class="text-base-content/40">→</span> ${escapeHtml(reviewed)}</td>
+                    <td class="text-sm text-base-content/60">${TimeUtils.getRelativeTime(review.createdDate)}</td>
+                    <td>${statusCell}</td>
+                    <td>${actionCell}</td>
+                </tr>`;
+            }).join('');
+
+            renderReviewPagination(data.totalPages || 0, data.currentPage || 0);
+            lucide.createIcons();
+        }
+
+        function renderReviewPagination(totalPages, current) {
+            const pagination = document.getElementById('reviewsPagination');
+            if (totalPages <= 1) { pagination.innerHTML = ''; return; }
+            let html = '';
+            for (let i = 0; i < totalPages; i++) {
+                html += `<button class="join-item btn btn-sm ${i === current ? 'btn-active' : ''}" onclick="loadReviews(${i})">${i + 1}</button>`;
+            }
+            pagination.innerHTML = html;
+        }
+
+        // 블라인드 모달
+        function openBlindModal(reviewId) {
+            document.getElementById('blindTargetReviewId').value = reviewId;
+            document.getElementById('blindReasonInput').value = '';
+            document.getElementById('blindModal').showModal();
+        }
+
+        document.getElementById('confirmBlind').addEventListener('click', () => {
+            const reviewId = document.getElementById('blindTargetReviewId').value;
+            const reason = document.getElementById('blindReasonInput').value;
+            const formData = new FormData();
+            formData.append('tradeReviewId', reviewId);
+            if (reason) formData.append('blindReason', reason);
+
+            fetch('/api/admin/reviews/blind', { method: 'POST', body: formData, credentials: 'same-origin' })
+                .then(r => { if (!r.ok) throw new Error(r.status); return r; })
+                .then(() => {
+                    document.getElementById('blindModal').close();
+                    loadReviews(currentReviewPage);
+                })
+                .catch(e => { console.error('블라인드 처리 실패:', e); alert('블라인드 처리 실패'); });
+        });
+
+        function unblindReview(reviewId) {
+            if (!confirm('이 후기의 블라인드를 해제할까요?')) return;
+            const formData = new FormData();
+            formData.append('tradeReviewId', reviewId);
+            fetch('/api/admin/reviews/unblind', { method: 'POST', body: formData, credentials: 'same-origin' })
+                .then(r => { if (!r.ok) throw new Error(r.status); return r; })
+                .then(() => loadReviews(currentReviewPage))
+                .catch(e => { console.error('블라인드 해제 실패:', e); alert('블라인드 해제 실패'); });
+        }
+
+        document.getElementById('applyFilter').addEventListener('click', () => loadReviews(0));
+
+        loadReviews(0);
+    </script>
+</th:block>
+</body>
+</html>

--- a/RomRom-Web/src/main/resources/templates/admin/trades.html
+++ b/RomRom-Web/src/main/resources/templates/admin/trades.html
@@ -156,7 +156,17 @@
         };
 
         document.addEventListener('DOMContentLoaded', function () {
-            const requestedTradeRequestHistoryId = new URLSearchParams(location.search).get('tradeRequestHistoryId');
+            const urlParams = new URLSearchParams(location.search);
+
+            // 대시보드 카드 드릴다운에서 넘어온 필터(tradeStatus/startDate/endDate)를 폼에 복원
+            // → loadTrades()가 DOM 필드값을 읽어 그대로 목록 필터에 반영한다
+            ['tradeStatus', 'startDate', 'endDate'].forEach(paramKey => {
+                const paramValue = urlParams.get(paramKey);
+                const fieldElement = document.getElementById(paramKey);
+                if (paramValue && fieldElement) fieldElement.value = paramValue;
+            });
+
+            const requestedTradeRequestHistoryId = urlParams.get('tradeRequestHistoryId');
             loadTrades().then(() => {
                 if (requestedTradeRequestHistoryId) viewTradeDetail(requestedTradeRequestHistoryId);
             });

--- a/docs/superpowers/specs/2026-06-04-admin-review-blind-design.md
+++ b/docs/superpowers/specs/2026-06-04-admin-review-blind-design.md
@@ -29,7 +29,7 @@ public class BlindInfo {
 }
 ```
 
-- 위치: `RomRom-Common` (여러 도메인 재사용 대비)
+- 위치: `RomRom-Common`, `com.romrom.common.entity.postgres.BlindInfo` (BasePostgresEntity 와 같은 패키지 — CLAUDE.md Common 규칙: 도메인 서브패키지 금지, `entity/postgres` 직하)
 - 이번 적용 대상은 `TradeReview` **하나로 한정** (물품 통합은 별도 작업, 과설계 금지)
 - DB: 별도 테이블 없이 `trade_review` 테이블에 4컬럼으로 펼쳐짐
 
@@ -43,6 +43,8 @@ public interface Blindable {
 ```
 
 `TradeReview`가 구현 → admin 서비스가 엔티티 종류와 무관하게 동일 흐름으로 블라인드/해제 처리.
+
+- 위치: `RomRom-Common`, `com.romrom.common.entity.postgres.Blindable` (BlindInfo 와 짝, 같은 패키지에 둠)
 
 ## 3. 엔티티 변경
 

--- a/docs/superpowers/specs/2026-06-04-admin-review-blind-design.md
+++ b/docs/superpowers/specs/2026-06-04-admin-review-blind-design.md
@@ -1,0 +1,168 @@
+# Admin 후기 블라인드 관리 — 설계 문서
+
+- 이슈: #771 (부모 Epic #707)
+- 작성일: 2026-06-04
+- 작성자: SUH SAECHAN
+
+## 1. 배경 / 문제
+
+거래 후기(`TradeReview`)는 현재 조회만 가능하고, 운영자가 부적절한 후기를 숨기거나 추적할 수단이 없다. 단순 Hard delete는 분쟁/소명 근거를 남기지 못한다. "누가·언제·왜 블라인드 처리했는지" 추적이 가능해야 하고, 일반 사용자에게는 후기 자리를 남긴 채 "관리자에 의해 블라인드 처리된 후기입니다" 안내로 치환해야 한다.
+
+기존 물품 숨김(#712)은 `isAdminHidden`/`adminHideReason` 2필드만 있고 **처리자/시각 추적이 없다**. 후기는 추적 필드를 포함한다.
+
+## 2. 공통 블라인드 묶음 (`@Embeddable BlindInfo`)
+
+운영자 블라인드 처리는 후기뿐 아니라 다른 도메인에서도 재사용될 공통 관심사다. 4필드를 `@Embeddable` 묶음으로 추출한다.
+
+`@MappedSuperclass`(상속)가 아니라 `@Embeddable`(품기)을 쓰는 이유: `TradeReview`는 이미 `BasePostgresEntity`를 상속 중이라 단일상속이 막혀 있고, 블라인드 정보는 엔티티의 "정체성"이 아니라 "부가 기능"이므로 품기가 의미상 맞다.
+
+```java
+// RomRom-Common
+@Embeddable
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+public class BlindInfo {
+    private Boolean isBlinded = false;   // 블라인드 처리 여부 (Boolean is 접두사 규칙)
+    private String blindReason;          // 블라인드 사유
+    private UUID blindByAdminId;         // 처리한 관리자 식별자
+    private LocalDateTime blindDate;     // 처리 시각
+}
+```
+
+- 위치: `RomRom-Common` (여러 도메인 재사용 대비)
+- 이번 적용 대상은 `TradeReview` **하나로 한정** (물품 통합은 별도 작업, 과설계 금지)
+- DB: 별도 테이블 없이 `trade_review` 테이블에 4컬럼으로 펼쳐짐
+
+### 처리 계약 `Blindable`
+
+```java
+public interface Blindable {
+    void blind(String blindReason, UUID blindByAdminId);
+    void unblind();
+}
+```
+
+`TradeReview`가 구현 → admin 서비스가 엔티티 종류와 무관하게 동일 흐름으로 블라인드/해제 처리.
+
+## 3. 엔티티 변경
+
+```java
+@Entity
+public class TradeReview extends BasePostgresEntity implements Blindable {
+    // ... 기존 필드 ...
+
+    @Embedded
+    private BlindInfo blindInfo = new BlindInfo();
+
+    @Override
+    public void blind(String blindReason, UUID blindByAdminId) {
+        this.blindInfo.setIsBlinded(true);
+        this.blindInfo.setBlindReason(blindReason);
+        this.blindInfo.setBlindByAdminId(blindByAdminId);
+        this.blindInfo.setBlindDate(LocalDateTime.now());
+    }
+
+    @Override
+    public void unblind() {
+        this.blindInfo.setIsBlinded(false);
+        this.blindInfo.setBlindReason(null);
+        this.blindInfo.setBlindByAdminId(null);
+        this.blindInfo.setBlindDate(null);
+    }
+}
+```
+
+## 4. 마이그레이션 (Flyway)
+
+`docs/flyway_guideline.md` 및 기존 `V1_4_60__add_item_admin_hidden_columns.sql` 패턴 100% 준수.
+
+- 파일명: 구현 직전 `git pull` + `build.gradle` 버전 확인 후 확정 (가이드 §버전체계 필수). 후보 `V1_4_62__add_trade_review_blind_columns.sql`
+- 컬럼별로 `테이블 존재(IF EXISTS) + 컬럼 부재(NOT EXISTS)` 가드 분리
+- `is_blinded BOOLEAN NOT NULL DEFAULT false`, `blind_reason VARCHAR(500)`, `blind_by_admin_id UUID`, `blind_date TIMESTAMP`
+- `DO $$ BEGIN ... EXCEPTION WHEN OTHERS THEN RAISE WARNING '오류 발생: %', SQLERRM; END $$;` 멱등 블록
+- 여러 번 실행해도 안전(idempotent)
+
+```sql
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_review')
+    AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'is_blinded') THEN
+        ALTER TABLE trade_review ADD COLUMN is_blinded BOOLEAN NOT NULL DEFAULT false;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_review')
+    AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_reason') THEN
+        ALTER TABLE trade_review ADD COLUMN blind_reason VARCHAR(500);
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_review')
+    AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_by_admin_id') THEN
+        ALTER TABLE trade_review ADD COLUMN blind_by_admin_id UUID;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_review')
+    AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'trade_review' AND column_name = 'blind_date') THEN
+        ALTER TABLE trade_review ADD COLUMN blind_date TIMESTAMP;
+    END IF;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING '오류 발생: %', SQLERRM;
+END $$;
+```
+
+## 5. 일반 사용자 노출 정책
+
+- 블라인드된 후기 = **자리 남기고 문구 치환** (아예 제외하지 않음)
+- `TradeReviewService.getReceivedTradeReviews` 응답 조립 시: `isBlinded == true`면 rating/comment/tags 를 마스킹하고 "관리자에 의해 블라인드 처리된 후기입니다" 안내 노출
+- 카드 자체와 작성 시각은 보임
+- 해당 사용자 API Docs `@ApiChangeLog` 갱신
+
+### 평점 평균
+- 현재 회원 평점 평균/통계 계산 기능이 코드에 **없음** → 이번 범위 아님
+- 후기 조회 쿼리에 블라인드 구분을 두어, 추후 평균 기능 추가 시 블라인드 후기를 자동 제외할 수 있게 한다
+
+## 6. Admin API
+
+admin 컨벤션 준수: `POST` + `multipart/form-data` + `@ModelAttribute`, 공용 `AdminRequest`/`AdminResponse` (별도 DTO 금지), `success`/`message` 필드 없음(HTTP 상태코드 + CustomException).
+
+| 엔드포인트 | 동작 |
+|---|---|
+| `POST /api/admin/reviews/list` | 평점/기간/블라인드여부 필터 + 페이지네이션. reviewer/reviewed/거래 deep-link |
+| `POST /api/admin/reviews/blind` | `tradeReviewId` + `blindReason` → 블라인드 처리 (blindByAdminId/blindDate 기록) |
+| `POST /api/admin/reviews/unblind` | `tradeReviewId` → 블라인드 해제 (필드 초기화) |
+
+- `AdminReviewService` 신규 (`RomRom-Application/service`), `Blindable` 계약 기반
+- `AdminReviewControllerDocs` 작성 + `@ApiChangeLog` 최상단 추가
+- `AdminRequest`에 `tradeReviewId` / `blindReason` / 블라인드 필터 필드 추가
+- `AdminResponse`에 `reviews`(Page<TradeReview>) 추가
+- `TradeReviewRepository`에 관리자용 목록 쿼리(평점/기간/블라인드 필터) 추가
+
+## 7. ErrorCode
+
+- `TRADE_REVIEW_NOT_FOUND` (404) — 블라인드/해제 대상 후기 없음 (기존 `TRADE_REVIEW_*` 패턴 따름)
+
+## 8. 권한 / 관리자 식별
+
+- 블라인드/해제/목록 = `ROLE_ADMIN` 전용 (`/api/admin/**` 시큐리티 기적용)
+- `blindByAdminId` = 처리 관리자 식별자. admin 인증 컨텍스트에서 추출 (기존 admin 인증 패턴 확인 후 적용)
+
+## 9. Admin 화면
+
+- `templates/admin/reviews.html` 신규 — 목록(평점/기간/블라인드 필터) + 블라인드 처리 모달(사유 입력) + 해제 버튼
+- 블라인드된 행 = "🔒 블라인드 처리됨 (처리자/시각/사유)" 표시
+- `templates/admin/layout.html` 좌측 메뉴에 "후기 관리"(currentMenu="reviews") 추가
+- `AdminPageController`에 `/admin/reviews` GET 매핑 추가 → reviews.html 렌더
+- #714 대시보드 "신규 후기" 카드 → 본 이슈 완료 후 `/admin/reviews` 링크 연결
+
+## 10. 작업 범위
+
+이번 #771 = **전체** (엔티티/마이그레이션/서비스/API/조회차단/admin 화면/메뉴/#714 연결). 평점 평균 집계는 기능 부재로 제외.
+
+## 11. 검증
+
+- 마이그레이션 재실행 멱등성 검증
+- 블라인드 → 일반 사용자 API 노출 치환 검증 (rating/comment/tags 마스킹)
+- 처리 이력(blindByAdminId/blindDate/blindReason) 기록 검증
+- 블라인드/해제 토글 동작 검증
+- 통합 테스트


### PR DESCRIPTION
## 개요

Admin 대시보드를 통계 관제판으로 개편(#714)하고, 후기 블라인드 관리 기능(#771)을 추가합니다.

관련 이슈
- https://github.com/TEAM-ROMROM/RomRom-BE/issues/714
- https://github.com/TEAM-ROMROM/RomRom-BE/issues/771
- 부모 Epic: https://github.com/TEAM-ROMROM/RomRom-BE/issues/707

## #714 대시보드 통합 개편

- 거래 상태별 통계 카드를 **데이터 주도**(`Map<TradeStatus,Long>`)로 반환 — `TradeStatus` enum 추가 시 무수정 확장
- 상태별 카운트는 `group by` 단일 집계 쿼리 (상태마다 분기 X)
- 기간 필터(전체/오늘/7일/30일/직접선택) + 카드 클릭 드릴다운
- 최근 교환완료(TRADED) 거래 리스트 (`/dashboard/recent-trades` 신규)
- 신규 후기 카운트 카드, 기존 위젯(최근 가입회원/물품) 유지
- `AdminDashboardService` 신규 (`RomRom-Application/service`)

## #771 후기 블라인드 관리

- 공통 `BlindInfo`(`@Embeddable`: isBlinded/blindReason/blindByAdminId/blindDate) + `Blindable` 계약 (`RomRom-Common`)
  - 상속 충돌 회피 위해 `@MappedSuperclass`가 아닌 `@Embeddable` 품기 채택 (이번 적용은 `TradeReview` 한정)
- Flyway `V1_4_62__add_trade_review_blind_columns.sql` — 기존 `V1_4_60` 패턴 100% (컬럼별 IF EXISTS 가드 + 멱등 블록)
- `AdminReviewService` + `/reviews/list·blind·unblind` API, `TRADE_REVIEW_NOT_FOUND` 에러코드
- 일반 사용자 후기 조회 시 블라인드 후기는 "관리자에 의해 블라인드 처리된 후기입니다"로 치환 (자리 유지, 원본 보존)
- admin `reviews.html` + 좌측 메뉴 "후기 관리" + `/admin/reviews` 페이지 매핑

## 주의 / 미검증

- ⚠️ 내부망 환경이라 로컬 빌드 미검증 — 머지 전 `./gradlew build` 필요
- 특히 확인 필요: JPQL embedded 경로(`r.blindInfo.isBlinded`), SuperBuilder + `@Embedded` 기본값 동작
- 평점 평균 집계는 현재 기능 부재로 범위 제외 (조회 쿼리에 블라인드 필터를 깔아 추후 평균 추가 시 자동 제외 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 관리자 대시보드에 거래 상태별 통계 및 최근 교환완료 거래 카드 추가
  * 관리자 후기 관리 페이지 신설 (목록 조회, 필터링, 블라인드 처리/해제)
  * 부적절한 후기에 대한 블라인드 처리 기능 추가 (관리자 전용)
  * 블라인드된 후기는 사용자 화면에서 마스킹 처리하여 표시

* **Bug Fixes**
  * 기간 필터를 통한 정확한 대시보드 통계 조회

<!-- end of auto-generated comment: release notes by coderabbit.ai -->