### PR TITLE
20260605_#777_카카오_Firebase_Custom_Token_발급_API_추가_및_소셜_로그인_연동_수정 : feat : 카카오 Firebase Custom Token 발급 API 추가 및 소셜 로그인 연동 https://github.com/TEAM-ROMROM/RomRom-BE/issues/777

### DIFF
--- a/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
@@ -46,6 +46,8 @@ public enum ErrorCode {
 
   SOCIAL_API_ERROR(HttpStatus.BAD_GATEWAY, "소셜 로그인 API 호출에 실패하였습니다."),
 
+  KAKAO_API_ERROR(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 조회에 실패하였습니다."),
+
   INVALID_SOCIAL_MEMBER_INFO(HttpStatus.BAD_REQUEST, "소셜 로그인 회원 정보가 올바르지 않습니다."),
 
   // FIREBASE
@@ -53,8 +55,6 @@ public enum ErrorCode {
   INVALID_FIREBASE_TOKEN(HttpStatus.UNAUTHORIZED, "Firebase 인증 토큰이 유효하지 않습니다."),
 
   EXPIRED_FIREBASE_TOKEN(HttpStatus.UNAUTHORIZED, "Firebase 인증 토큰이 만료되었습니다."),
-
-  KAKAO_API_ERROR(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 조회에 실패하였습니다."),
 
   FIREBASE_CUSTOM_TOKEN_ISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase Custom Token 발급에 실패하였습니다."),
 

--- a/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
+++ b/RomRom-Common/src/main/java/com/romrom/common/exception/ErrorCode.java
@@ -54,6 +54,10 @@ public enum ErrorCode {
 
   EXPIRED_FIREBASE_TOKEN(HttpStatus.UNAUTHORIZED, "Firebase 인증 토큰이 만료되었습니다."),
 
+  KAKAO_API_ERROR(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 조회에 실패하였습니다."),
+
+  FIREBASE_CUSTOM_TOKEN_ISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase Custom Token 발급에 실패하였습니다."),
+
   // MEMBER
 
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/KakaoFirebaseTokenRequest.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/KakaoFirebaseTokenRequest.java
@@ -1,0 +1,19 @@
+package com.romrom.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoFirebaseTokenRequest {
+
+  @Schema(description = "카카오 SDK에서 발급된 accessToken", example = "KXFyGq7...")
+  private String accessToken;
+}

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/KakaoFirebaseTokenResponse.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/KakaoFirebaseTokenResponse.java
@@ -1,0 +1,17 @@
+package com.romrom.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoFirebaseTokenResponse {
+
+  @Schema(description = "Firebase signInWithCustomToken()에 사용할 Custom Token")
+  private String customToken;
+}

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/SecurityUrls.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/SecurityUrls.java
@@ -17,8 +17,9 @@ public class SecurityUrls {
     "/actuator/health",
 
     // auth
-    "/api/auth/login",   // Firebase 통합 로그인
-    "/api/auth/reissue", // accessToken 재발급
+    "/api/auth/login",                    // Firebase 통합 로그인
+    "/api/auth/reissue",                  // accessToken 재발급
+    "/api/auth/kakao/firebase-token",     // 카카오 Firebase Custom Token 발급
 
     // public item - 카카오톡 공유 OG 태그 렌더링용 (Cloud Function 경유 호출)
     "/api/item/public/get",

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/AuthService.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/AuthService.java
@@ -61,35 +61,73 @@ public class AuthService {
 
     log.debug("Firebase 로그인 시도: email={}, providerId={}, platform={}", email, request.getProviderId(), socialPlatform);
 
-    Optional<Member> existMember = memberRepository.findByEmail(email);
+    Optional<Member> existMember;
     Member member;
-    if (existMember.isPresent()) {
-      member = existMember.get();
-      if (member.getSocialPlatform() != socialPlatform) {
-        throw new EmailAlreadyRegisteredException(member.getSocialPlatform());
+
+    if (socialPlatform == SocialPlatform.KAKAO) {
+      // 카카오 Custom Token 방식: Firebase UID(kakao:{카카오회원번호})로 회원 조회
+      String kakaoFirebaseUid = firebaseToken.getUid();
+      existMember = memberRepository.findByFirebaseUid(kakaoFirebaseUid);
+
+      if (existMember.isPresent()) {
+        member = existMember.get();
+        member.setIsFirstLogin(false);
+      } else {
+        // 신규 카카오 회원
+        member = Member.builder()
+            .email(email)
+            .firebaseUid(kakaoFirebaseUid)
+            .nickname(nickname)
+            .socialPlatform(socialPlatform)
+            .profileUrl(profileUrl)
+            .role(Role.ROLE_USER)
+            .accountStatus(AccountStatus.ACTIVE_ACCOUNT)
+            .isFirstLogin(true)
+            .isFirstItemPosted(false)
+            .isItemCategorySaved(false)
+            .isMemberLocationSaved(false)
+            .isRequiredTermsAgreed(false)
+            .isMarketingInfoAgreed(false)
+            .isActivityNotificationAgreed(false)
+            .isChatNotificationAgreed(false)
+            .isContentNotificationAgreed(false)
+            .isTradeNotificationAgreed(false)
+            .isDeleted(false)
+            .totalLikeCount(0)
+            .build();
       }
-      member.setIsFirstLogin(false);
-    } else { // 신규 회원
-      member = Member.builder()
-          .email(email)
-          .nickname(nickname)
-          .socialPlatform(socialPlatform)
-          .profileUrl(profileUrl)
-          .role(Role.ROLE_USER)
-          .accountStatus(AccountStatus.ACTIVE_ACCOUNT)
-          .isFirstLogin(true)
-          .isFirstItemPosted(false)
-          .isItemCategorySaved(false)
-          .isMemberLocationSaved(false)
-          .isRequiredTermsAgreed(false)
-          .isMarketingInfoAgreed(false)
-          .isActivityNotificationAgreed(false)
-          .isChatNotificationAgreed(false)
-          .isContentNotificationAgreed(false)
-          .isTradeNotificationAgreed(false)
-          .isDeleted(false)
-          .totalLikeCount(0)
-          .build();
+    } else {
+      existMember = memberRepository.findByEmail(email);
+
+      if (existMember.isPresent()) {
+        member = existMember.get();
+        if (member.getSocialPlatform() != socialPlatform) {
+          throw new EmailAlreadyRegisteredException(member.getSocialPlatform());
+        }
+        member.setIsFirstLogin(false);
+      } else {
+        // 신규 Google/Apple 회원
+        member = Member.builder()
+            .email(email)
+            .nickname(nickname)
+            .socialPlatform(socialPlatform)
+            .profileUrl(profileUrl)
+            .role(Role.ROLE_USER)
+            .accountStatus(AccountStatus.ACTIVE_ACCOUNT)
+            .isFirstLogin(true)
+            .isFirstItemPosted(false)
+            .isItemCategorySaved(false)
+            .isMemberLocationSaved(false)
+            .isRequiredTermsAgreed(false)
+            .isMarketingInfoAgreed(false)
+            .isActivityNotificationAgreed(false)
+            .isChatNotificationAgreed(false)
+            .isContentNotificationAgreed(false)
+            .isTradeNotificationAgreed(false)
+            .isDeleted(false)
+            .totalLikeCount(0)
+            .build();
+      }
     }
     memberRepository.save(member);
 
@@ -166,7 +204,7 @@ public class AuthService {
     }
     return switch (providerId) {
       case "google.com" -> SocialPlatform.GOOGLE;
-      case "oidc.kakao" -> SocialPlatform.KAKAO;
+      case "oidc.kakao", "kakao" -> SocialPlatform.KAKAO;
       case "apple.com" -> SocialPlatform.APPLE;
       default -> throw new CustomException(ErrorCode.INVALID_SOCIAL_PLATFORM);
     };

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/AuthService.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/AuthService.java
@@ -65,12 +65,27 @@ public class AuthService {
     Member member;
 
     if (socialPlatform == SocialPlatform.KAKAO) {
-      // 카카오 Custom Token 방식: Firebase UID(kakao:{카카오회원번호})로 회원 조회
       String kakaoFirebaseUid = firebaseToken.getUid();
-      existMember = memberRepository.findByFirebaseUid(kakaoFirebaseUid);
+
+      // 1차: email 기반 조회 (기존 oidc.kakao 회원 포함, email 동의한 경우)
+      existMember = (email != null)
+          ? memberRepository.findByEmail(email)
+          : Optional.empty();
+
+      // 2차: email 없거나 조회 실패 시 firebaseUid로 조회 (이메일 미동의 회원)
+      if (existMember.isEmpty()) {
+        existMember = memberRepository.findByFirebaseUid(kakaoFirebaseUid);
+      }
 
       if (existMember.isPresent()) {
         member = existMember.get();
+        if (member.getSocialPlatform() != socialPlatform) {
+          throw new EmailAlreadyRegisteredException(member.getSocialPlatform());
+        }
+        // oidc.kakao → custom token 전환 시 firebaseUid 최초 세팅
+        if (member.getFirebaseUid() == null) {
+          member.setFirebaseUid(kakaoFirebaseUid);
+        }
         member.setIsFirstLogin(false);
       } else {
         // 신규 카카오 회원

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/KakaoAuthService.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/KakaoAuthService.java
@@ -1,0 +1,99 @@
+package com.romrom.auth.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.romrom.auth.dto.KakaoFirebaseTokenRequest;
+import com.romrom.auth.dto.KakaoFirebaseTokenResponse;
+import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.ErrorCode;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+  private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+  private static final String KAKAO_UID_PREFIX = "kakao:";
+
+  private final OkHttpClient okHttpClient;
+  private final ObjectMapper objectMapper;
+
+  /**
+   * 카카오 accessToken으로 Firebase Custom Token 발급
+   * 1. 카카오 사용자 정보 API 호출 → 카카오 회원번호 획득
+   * 2. firebaseUid = "kakao:{카카오회원번호}"로 Firebase Custom Token 생성
+   */
+  public KakaoFirebaseTokenResponse issueFirebaseCustomToken(KakaoFirebaseTokenRequest request) {
+    String kakaoAccessToken = request.getAccessToken();
+
+    if (kakaoAccessToken == null || kakaoAccessToken.isBlank()) {
+      throw new CustomException(ErrorCode.EMPTY_SOCIAL_AUTH_TOKEN);
+    }
+
+    long kakaoUserId = fetchKakaoUserId(kakaoAccessToken);
+    String kakaoFirebaseUid = KAKAO_UID_PREFIX + kakaoUserId;
+
+    String firebaseCustomToken = createFirebaseCustomToken(kakaoFirebaseUid);
+
+    log.debug("Firebase Custom Token 발급 완료: kakaoUserId={}, firebaseUid={}", kakaoUserId, kakaoFirebaseUid);
+
+    return KakaoFirebaseTokenResponse.builder()
+        .customToken(firebaseCustomToken)
+        .build();
+  }
+
+  /**
+   * 카카오 사용자 정보 API를 호출하여 카카오 회원번호를 반환
+   */
+  private long fetchKakaoUserId(String kakaoAccessToken) {
+    Request kakaoRequest = new Request.Builder()
+        .url(KAKAO_USER_INFO_URL)
+        .addHeader("Authorization", "Bearer " + kakaoAccessToken)
+        .get()
+        .build();
+
+    try (Response kakaoResponse = okHttpClient.newCall(kakaoRequest).execute()) {
+      if (!kakaoResponse.isSuccessful() || kakaoResponse.body() == null) {
+        log.error("카카오 사용자 정보 조회 실패: status={}", kakaoResponse.code());
+        throw new CustomException(ErrorCode.KAKAO_API_ERROR);
+      }
+
+      String responseBodyJson = kakaoResponse.body().string();
+      JsonNode kakaoUserInfo = objectMapper.readTree(responseBodyJson);
+      JsonNode kakaoUserIdNode = kakaoUserInfo.get("id");
+
+      if (kakaoUserIdNode == null || kakaoUserIdNode.isNull()) {
+        log.error("카카오 사용자 정보에서 id 필드 없음: body={}", responseBodyJson);
+        throw new CustomException(ErrorCode.INVALID_SOCIAL_MEMBER_INFO);
+      }
+
+      return kakaoUserIdNode.asLong();
+
+    } catch (IOException ioException) {
+      log.error("카카오 API 호출 중 IO 오류: {}", ioException.getMessage());
+      throw new CustomException(ErrorCode.KAKAO_API_ERROR);
+    }
+  }
+
+  /**
+   * Firebase Admin SDK로 Custom Token 생성
+   */
+  private String createFirebaseCustomToken(String kakaoFirebaseUid) {
+    try {
+      return FirebaseAuth.getInstance().createCustomToken(kakaoFirebaseUid);
+    } catch (FirebaseAuthException firebaseAuthException) {
+      log.error("Firebase Custom Token 발급 실패: uid={}, code={}, message={}",
+          kakaoFirebaseUid, firebaseAuthException.getAuthErrorCode(), firebaseAuthException.getMessage());
+      throw new CustomException(ErrorCode.FIREBASE_CUSTOM_TOKEN_ISSUE_FAILED);
+    }
+  }
+}

--- a/RomRom-Domain-Member/src/main/java/com/romrom/member/entity/Member.java
+++ b/RomRom-Domain-Member/src/main/java/com/romrom/member/entity/Member.java
@@ -37,7 +37,7 @@ public class Member extends BasePostgresEntity {
   private String email;
 
   // 카카오 Custom Token 방식 로그인 시 Firebase UID (kakao:{카카오회원번호} 형식)
-  @Column(name = "firebase_uid", unique = true)
+  @Column(unique = true)
   private String firebaseUid;
 
   @Column(unique = true)

--- a/RomRom-Domain-Member/src/main/java/com/romrom/member/entity/Member.java
+++ b/RomRom-Domain-Member/src/main/java/com/romrom/member/entity/Member.java
@@ -36,6 +36,10 @@ public class Member extends BasePostgresEntity {
   @Column(unique = true)
   private String email;
 
+  // 카카오 Custom Token 방식 로그인 시 Firebase UID (kakao:{카카오회원번호} 형식)
+  @Column(name = "firebase_uid", unique = true)
+  private String firebaseUid;
+
   @Column(unique = true)
   private String nickname;
 

--- a/RomRom-Domain-Member/src/main/java/com/romrom/member/repository/MemberRepository.java
+++ b/RomRom-Domain-Member/src/main/java/com/romrom/member/repository/MemberRepository.java
@@ -17,6 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
 
   Optional<Member> findByEmail(String email);
 
+  Optional<Member> findByFirebaseUid(String firebaseUid);
+
   Optional<Member> findByEmailAndIsDeletedFalse(String email);
 
   Boolean existsByNicknameAndMemberIdNot(String nickname, UUID memberId);

--- a/RomRom-Web/src/main/java/com/romrom/web/config/HttpClientConfig.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/config/HttpClientConfig.java
@@ -1,0 +1,14 @@
+package com.romrom.web.config;
+
+import okhttp3.OkHttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HttpClientConfig {
+
+  @Bean
+  public OkHttpClient okHttpClient() {
+    return new OkHttpClient();
+  }
+}

--- a/RomRom-Web/src/main/java/com/romrom/web/config/HttpClientConfig.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/config/HttpClientConfig.java
@@ -1,5 +1,6 @@
 package com.romrom.web.config;
 
+import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +10,10 @@ public class HttpClientConfig {
 
   @Bean
   public OkHttpClient okHttpClient() {
-    return new OkHttpClient();
+    return new OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .writeTimeout(10, TimeUnit.SECONDS)
+        .build();
   }
 }

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthController.java
@@ -61,6 +61,6 @@ public class AuthController implements AuthControllerDocs {
   @LogMonitor
   public ResponseEntity<KakaoFirebaseTokenResponse> issueKakaoFirebaseToken(
       @RequestBody KakaoFirebaseTokenRequest request) {
-    return ResponseEntity.ok(kakaoAuthService.issueFirebaseToken(request));
+    return ResponseEntity.ok(kakaoAuthService.issueFirebaseCustomToken(request));
   }
 }

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthController.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthController.java
@@ -3,8 +3,11 @@ package com.romrom.web.controller.api;
 import com.romrom.auth.dto.AuthRequest;
 import com.romrom.auth.dto.AuthResponse;
 import com.romrom.auth.dto.CustomUserDetails;
+import com.romrom.auth.dto.KakaoFirebaseTokenRequest;
+import com.romrom.auth.dto.KakaoFirebaseTokenResponse;
 import com.romrom.auth.dto.LoginRequest;
 import com.romrom.auth.service.AuthService;
+import com.romrom.auth.service.KakaoAuthService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import me.suhsaechan.suhlogger.annotation.LogMonitor;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController implements AuthControllerDocs {
   private final AuthService authService;
+  private final KakaoAuthService kakaoAuthService;
 
   @Override
   @PostMapping(value = "/login", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -50,5 +54,13 @@ public class AuthController implements AuthControllerDocs {
     request.setMember(customUserDetails.getMember());
     authService.logout(request);
     return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PostMapping(value = "/kakao/firebase-token", consumes = MediaType.APPLICATION_JSON_VALUE)
+  @LogMonitor
+  public ResponseEntity<KakaoFirebaseTokenResponse> issueKakaoFirebaseToken(
+      @RequestBody KakaoFirebaseTokenRequest request) {
+    return ResponseEntity.ok(kakaoAuthService.issueFirebaseToken(request));
   }
 }

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthControllerDocs.java
@@ -3,6 +3,8 @@ package com.romrom.web.controller.api;
 import com.romrom.auth.dto.AuthRequest;
 import com.romrom.auth.dto.AuthResponse;
 import com.romrom.auth.dto.CustomUserDetails;
+import com.romrom.auth.dto.KakaoFirebaseTokenRequest;
+import com.romrom.auth.dto.KakaoFirebaseTokenResponse;
 import com.romrom.auth.dto.LoginRequest;
 import com.romrom.common.dto.Author;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 public interface AuthControllerDocs {
 
   @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.06.05", author = Author.BAEKJIHOON, issueNumber = 777, description = "카카오 Custom Token 방식 로그인 지원 추가 (providerId: kakao)"),
       @ApiChangeLog(date = "2026.03.27", author = Author.SUHSAECHAN, issueNumber = 605, description = "동일 이메일 다른 소셜 플랫폼 로그인 시 409 에러 응답 추가"),
       @ApiChangeLog(date = "2026.03.05", author = Author.WISEUNGJAE, issueNumber = 561, description = "Firebase Authentication 기반 통합 로그인으로 전환, 기존 /sign-in 제거"),
       @ApiChangeLog(date = "2026.01.13", author = Author.WISEUNGJAE, issueNumber = 446, description = "회원가입 시 알림수신여부 false로 초기화"),
@@ -30,7 +33,7 @@ public interface AuthControllerDocs {
 
       ## 요청 파라미터 (LoginRequest)
       - **`firebaseIdToken`**: Flutter Firebase Authentication에서 발급된 ID Token
-      - **`providerId`**: 소셜 로그인 제공자 ID (google.com, oidc.kakao)
+      - **`providerId`**: 소셜 로그인 제공자 ID (google.com, apple.com, oidc.kakao, kakao)
       - **`profile.email`**: 소셜 로그인 이메일 (서버에서 미사용, Firebase 토큰에서 추출)
       - **`profile.displayName`**: 소셜 로그인 닉네임 (서버에서 미사용, 랜덤 생성)
       - **`profile.photoUrl`**: 소셜 로그인 프로필 이미지 URL
@@ -58,6 +61,7 @@ public interface AuthControllerDocs {
       - **`EXPIRED_FIREBASE_TOKEN`**: 만료된 Firebase 인증 토큰입니다.
       - **`INVALID_SOCIAL_PLATFORM`**: 지원하지 않는 소셜 로그인 제공자입니다.
       - **`EMAIL_ALREADY_REGISTERED`**: 이미 다른 소셜 플랫폼으로 가입된 이메일입니다. (409 + EmailAlreadyRegisteredResponse: errorCode, registeredSocialPlatform)
+      - **`MEMBER_NOT_FOUND`**: 회원 정보를 찾을 수 없습니다. (카카오 Custom Token 방식)
       """
   )
   ResponseEntity<AuthResponse> login(LoginRequest request);
@@ -122,4 +126,32 @@ public interface AuthControllerDocs {
   ResponseEntity<Void> logout(
       CustomUserDetails customUserDetails,
       AuthRequest request);
+
+  @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.06.05", author = Author.BAEKJIHOON, issueNumber = 777, description = "카카오 Firebase Custom Token 발급 API 신규 추가"),
+  })
+  @Operation(
+      summary = "카카오 Firebase Custom Token 발급",
+      description = """
+      ## 인증(JWT): **불필요**
+
+      ## 요청 파라미터 (KakaoFirebaseTokenRequest)
+      - **`accessToken`**: 카카오 SDK에서 발급된 accessToken
+
+      ## 반환값 (KakaoFirebaseTokenResponse)
+      - **`customToken`**: Firebase signInWithCustomToken()에 사용할 Custom Token
+
+      ## 동작 설명
+      - 카카오 accessToken으로 카카오 사용자 정보(/v2/user/me)를 조회합니다
+      - kakao:{카카오회원번호} 형식의 Firebase UID로 Custom Token을 발급합니다
+      - 발급된 Custom Token은 FE에서 Firebase signInWithCustomToken() 호출에 사용됩니다
+
+      ## 에러코드
+      - **`EMPTY_SOCIAL_AUTH_TOKEN`**: 카카오 AccessToken이 없습니다.
+      - **`KAKAO_API_ERROR`**: 카카오 사용자 정보 조회에 실패하였습니다.
+      - **`INVALID_SOCIAL_MEMBER_INFO`**: 카카오 회원 ID를 가져올 수 없습니다.
+      - **`FIREBASE_CUSTOM_TOKEN_ISSUE_FAILED`**: Firebase Custom Token 발급에 실패하였습니다.
+      """
+  )
+  ResponseEntity<KakaoFirebaseTokenResponse> issueKakaoFirebaseToken(KakaoFirebaseTokenRequest request);
 }

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthControllerDocs.java
@@ -61,7 +61,6 @@ public interface AuthControllerDocs {
       - **`EXPIRED_FIREBASE_TOKEN`**: 만료된 Firebase 인증 토큰입니다.
       - **`INVALID_SOCIAL_PLATFORM`**: 지원하지 않는 소셜 로그인 제공자입니다.
       - **`EMAIL_ALREADY_REGISTERED`**: 이미 다른 소셜 플랫폼으로 가입된 이메일입니다. (409 + EmailAlreadyRegisteredResponse: errorCode, registeredSocialPlatform)
-      - **`MEMBER_NOT_FOUND`**: 회원 정보를 찾을 수 없습니다. (카카오 Custom Token 방식)
       """
   )
   ResponseEntity<AuthResponse> login(LoginRequest request);

--- a/RomRom-Web/src/main/resources/db/migration/V1_4_63__add_firebase_uid_to_member.sql
+++ b/RomRom-Web/src/main/resources/db/migration/V1_4_63__add_firebase_uid_to_member.sql
@@ -1,0 +1,19 @@
+DO $$
+BEGIN
+    -- firebase_uid 컬럼 추가 (카카오 Custom Token 방식 로그인 시 Firebase UID 저장)
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables WHERE table_name = 'member'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'member' AND column_name = 'firebase_uid'
+    ) THEN
+        ALTER TABLE member ADD COLUMN firebase_uid VARCHAR(255);
+
+        -- unique 제약 조건 추가 (null 제외, PostgreSQL에서 null은 unique 제약 미적용)
+        ALTER TABLE member ADD CONSTRAINT uq_member_firebase_uid UNIQUE (firebase_uid);
+    END IF;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'V1_4_63 마이그레이션 오류: %', SQLERRM;
+END $$;


### PR DESCRIPTION
## Summary

카카오 SDK accessToken을 받아 Firebase Custom Token으로 변환하는 신규 API(`POST /api/auth/kakao/firebase-token`)를 추가하고, 기존 통합 로그인(`/api/auth/login`)에서 `providerId: "kakao"` 방식을 지원합니다. 기존 `oidc.kakao` 방식 회원과의 호환성을 유지하며, 이메일 미동의 카카오 회원도 처리합니다.

## Changes

### 신규 API
- `POST /api/auth/kakao/firebase-token` — 카카오 accessToken → Firebase Custom Token 변환
- 카카오 `/v2/user/me` 호출 후 `kakao:{카카오회원번호}` 형식으로 Firebase UID 생성
- Firebase Admin SDK `createCustomToken()` 호출하여 Custom Token 반환

### 통합 로그인 KAKAO 분기
- `mapProviderIdToSocialPlatform()`에 `"kakao"` case 추가
- 식별자 전략: email 1차 조회 → firebaseUid 2차 조회 (이메일 미동의 회원 지원)
- 기존 `oidc.kakao` 회원 최초 custom token 로그인 시 firebaseUid 자동 세팅

### DB 스키마 변경
- `member` 테이블에 `firebase_uid VARCHAR(255) UNIQUE` 컬럼 추가 (Flyway V1_4_63)

### 인프라
- `OkHttpClient` Bean 등록 (`HttpClientConfig`): connectTimeout 5s / readTimeout 10s / writeTimeout 10s
- 에러코드 2개 추가: `KAKAO_API_ERROR (502)`, `FIREBASE_CUSTOM_TOKEN_ISSUE_FAILED (500)`

## Files Changed

| 파일 | 변경 유형 |
|------|----------|
| `RomRom-Common/.../exception/ErrorCode.java` | Modified |
| `RomRom-Domain-Auth/.../dto/KakaoFirebaseTokenRequest.java` | Added |
| `RomRom-Domain-Auth/.../dto/KakaoFirebaseTokenResponse.java` | Added |
| `RomRom-Domain-Auth/.../dto/SecurityUrls.java` | Modified |
| `RomRom-Domain-Auth/.../service/AuthService.java` | Modified |
| `RomRom-Domain-Auth/.../service/KakaoAuthService.java` | Added |
| `RomRom-Domain-Member/.../entity/Member.java` | Modified |
| `RomRom-Domain-Member/.../repository/MemberRepository.java` | Modified |
| `RomRom-Web/.../config/HttpClientConfig.java` | Added |
| `RomRom-Web/.../controller/api/AuthController.java` | Modified |
| `RomRom-Web/.../controller/api/AuthControllerDocs.java` | Modified |
| `RomRom-Web/.../db/migration/V1_4_63__add_firebase_uid_to_member.sql` | Added |

## Testing

- Gradle 빌드 (`BUILD SUCCESSFUL`) 확인
- 프로젝트 방침에 따라 단위/통합 테스트 코드 미작성
- FE 연동 전까지 실제 카카오 Custom Token 방식 로그인 동작 미검증

## Related Issues

Closes #777

## Artifacts

- `.report/20260605_#777_카카오_Firebase_Custom_Token_발급_API_추가.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 카카오 소셜 로그인을 위한 Firebase Custom Token 발급 기능 추가
  * 새로운 인증 API 엔드포인트 추가

* **Documentation**
  * API 문서 업데이트 (카카오 Firebase 토큰 발급 API 설명 추가)

* **Infrastructure**
  * 데이터베이스 스키마 업데이트 (Firebase UID 저장 필드 추가)
  * HTTP 클라이언트 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->