### PR TITLE
20260605_#777_카카오_Firebase_Custom_Token_발급_API_추가_및_소셜_로그인_연동_수정 : feat : KakaoFirebaseToken email 필드 추가 및 기존 카카오 회원 pre-matching 로직 추가 https://github.com/TEAM-ROMROM/RomRom-BE/issues/777

### DIFF
--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/KakaoFirebaseTokenRequest.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/dto/KakaoFirebaseTokenRequest.java
@@ -16,4 +16,7 @@ public class KakaoFirebaseTokenRequest {
 
   @Schema(description = "카카오 SDK에서 발급된 accessToken", example = "KXFyGq7...")
   private String accessToken;
+
+  @Schema(description = "카카오 계정 email (기존 카카오 회원 매칭 보조용, nullable)", example = "user@kakao.com")
+  private String email;
 }

--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/KakaoAuthService.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/KakaoAuthService.java
@@ -6,15 +6,21 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.romrom.auth.dto.KakaoFirebaseTokenRequest;
 import com.romrom.auth.dto.KakaoFirebaseTokenResponse;
+import com.romrom.common.constant.SocialPlatform;
 import com.romrom.common.exception.CustomException;
+import com.romrom.common.exception.EmailAlreadyRegisteredException;
 import com.romrom.common.exception.ErrorCode;
+import com.romrom.member.entity.Member;
+import com.romrom.member.repository.MemberRepository;
 import java.io.IOException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -26,12 +32,15 @@ public class KakaoAuthService {
 
   private final OkHttpClient okHttpClient;
   private final ObjectMapper objectMapper;
+  private final MemberRepository memberRepository;
 
   /**
    * 카카오 accessToken으로 Firebase Custom Token 발급
    * 1. 카카오 사용자 정보 API 호출 → 카카오 회원번호 획득
-   * 2. firebaseUid = "kakao:{카카오회원번호}"로 Firebase Custom Token 생성
+   * 2. 기존 회원 pre-matching: firebaseUid 1순위, email 2순위 (oidc.kakao 마이그레이션 대응)
+   * 3. firebaseUid = "kakao:{카카오회원번호}"로 Firebase Custom Token 생성
    */
+  @Transactional
   public KakaoFirebaseTokenResponse issueFirebaseCustomToken(KakaoFirebaseTokenRequest request) {
     String kakaoAccessToken = request.getAccessToken();
 
@@ -42,6 +51,10 @@ public class KakaoAuthService {
     long kakaoUserId = fetchKakaoUserId(kakaoAccessToken);
     String kakaoFirebaseUid = KAKAO_UID_PREFIX + kakaoUserId;
 
+    // 기존 회원 pre-matching: /login의 2차 findByFirebaseUid 조회가 성공하도록 firebaseUid 선세팅
+    // Custom Token 로그인 시 Firebase ID Token에 email이 없으므로 /login의 1차 email 조회가 항상 스킵됨
+    preMatchExistingMember(kakaoFirebaseUid, request.getEmail());
+
     String firebaseCustomToken = createFirebaseCustomToken(kakaoFirebaseUid);
 
     log.debug("Firebase Custom Token 발급 완료: kakaoUserId={}, firebaseUid={}", kakaoUserId, kakaoFirebaseUid);
@@ -49,6 +62,38 @@ public class KakaoAuthService {
     return KakaoFirebaseTokenResponse.builder()
         .customToken(firebaseCustomToken)
         .build();
+  }
+
+  /**
+   * 기존 카카오 회원의 firebaseUid를 미리 세팅하여 /login 2차 조회가 성공하도록 준비
+   * 1순위: firebaseUid로 조회 (이미 Custom Token 방식 사용 중인 회원)
+   * 2순위: email로 조회 (기존 oidc.kakao 회원 → custom token 방식 전환)
+   */
+  private void preMatchExistingMember(String kakaoFirebaseUid, String requestEmail) {
+    // 1순위: 이미 firebaseUid가 세팅된 회원 (재로그인)
+    Optional<Member> existMember = memberRepository.findByFirebaseUid(kakaoFirebaseUid);
+
+    // 2순위: email로 기존 카카오 회원 조회 (oidc.kakao 마이그레이션 회원)
+    if (existMember.isEmpty() && requestEmail != null && !requestEmail.isBlank()) {
+      existMember = memberRepository.findByEmail(requestEmail);
+    }
+
+    if (existMember.isEmpty()) {
+      return;
+    }
+
+    Member member = existMember.get();
+
+    if (member.getSocialPlatform() != SocialPlatform.KAKAO) {
+      throw new EmailAlreadyRegisteredException(member.getSocialPlatform());
+    }
+
+    // oidc.kakao → custom token 전환 시 firebaseUid 최초 세팅
+    if (member.getFirebaseUid() == null) {
+      member.setFirebaseUid(kakaoFirebaseUid);
+      memberRepository.save(member);
+      log.debug("기존 카카오 회원 firebaseUid 세팅 완료: email={}, firebaseUid={}", requestEmail, kakaoFirebaseUid);
+    }
   }
 
   /**

--- a/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthControllerDocs.java
+++ b/RomRom-Web/src/main/java/com/romrom/web/controller/api/AuthControllerDocs.java
@@ -127,6 +127,7 @@ public interface AuthControllerDocs {
       AuthRequest request);
 
   @ApiChangeLogs({
+      @ApiChangeLog(date = "2026.06.05", author = Author.BAEKJIHOON, issueNumber = 911, description = "기존 카카오 회원 매칭을 위한 email 필드 추가 및 pre-matching 로직 적용"),
       @ApiChangeLog(date = "2026.06.05", author = Author.BAEKJIHOON, issueNumber = 777, description = "카카오 Firebase Custom Token 발급 API 신규 추가"),
   })
   @Operation(
@@ -136,6 +137,7 @@ public interface AuthControllerDocs {
 
       ## 요청 파라미터 (KakaoFirebaseTokenRequest)
       - **`accessToken`**: 카카오 SDK에서 발급된 accessToken
+      - **`email`**: 카카오 계정 email (nullable, 기존 카카오 회원 매칭 보조용)
 
       ## 반환값 (KakaoFirebaseTokenResponse)
       - **`customToken`**: Firebase signInWithCustomToken()에 사용할 Custom Token
@@ -143,6 +145,9 @@ public interface AuthControllerDocs {
       ## 동작 설명
       - 카카오 accessToken으로 카카오 사용자 정보(/v2/user/me)를 조회합니다
       - kakao:{카카오회원번호} 형식의 Firebase UID로 Custom Token을 발급합니다
+      - 기존 카카오 회원(oidc.kakao 방식 포함)의 firebaseUid를 미리 세팅하여 /login 2차 조회가 성공하도록 준비합니다
+        - 1순위: firebaseUid로 기존 회원 조회 (이미 Custom Token 방식 사용 중인 회원)
+        - 2순위: email로 기존 카카오 회원 조회 (oidc.kakao → Custom Token 방식 전환)
       - 발급된 Custom Token은 FE에서 Firebase signInWithCustomToken() 호출에 사용됩니다
 
       ## 에러코드
@@ -150,6 +155,7 @@ public interface AuthControllerDocs {
       - **`KAKAO_API_ERROR`**: 카카오 사용자 정보 조회에 실패하였습니다.
       - **`INVALID_SOCIAL_MEMBER_INFO`**: 카카오 회원 ID를 가져올 수 없습니다.
       - **`FIREBASE_CUSTOM_TOKEN_ISSUE_FAILED`**: Firebase Custom Token 발급에 실패하였습니다.
+      - **`EMAIL_ALREADY_REGISTERED`**: 동일 이메일로 다른 소셜 플랫폼 계정이 이미 존재합니다.
       """
   )
   ResponseEntity<KakaoFirebaseTokenResponse> issueKakaoFirebaseToken(KakaoFirebaseTokenRequest request);


### PR DESCRIPTION
## Summary

`/api/auth/kakao/firebase-token` 요청에 `email` 필드를 추가하고, 기존 카카오 회원(oidc.kakao 방식 포함)의 `firebaseUid`를 미리 세팅하는 pre-matching 로직을 추가합니다. Custom Token 방식으로 Firebase 로그인 시 Firebase ID Token에 email이 없어 `/login` 1차 email 조회가 항상 스킵되는 문제를 해결합니다.

## Changes

### feat — KakaoFirebaseToken email 필드 추가 및 기존 회원 pre-matching
- `KakaoFirebaseTokenRequest`에 `email` 필드(nullable) 추가
- `KakaoAuthService`에 `preMatchExistingMember()` 메서드 신규 추가
  - 1순위: `findByFirebaseUid` (이미 Custom Token 방식 사용 중인 회원)
  - 2순위: `findByEmail(requestEmail)` (기존 oidc.kakao 회원 → Custom Token 방식 전환)
  - 기존 카카오 회원의 `firebaseUid`가 null이면 `kakao:{kakaoUserId}`로 세팅 후 저장
  - 비KAKAO 플랫폼 이메일 충돌 시 `EmailAlreadyRegisteredException`
- `@Transactional`, `MemberRepository` DI 추가

### docs — AuthControllerDocs Swagger 업데이트
- `issueKakaoFirebaseToken` @ApiChangeLog 이슈 #911 이력 추가
- `email` 필드 설명, pre-matching 동작 설명, `EMAIL_ALREADY_REGISTERED` 에러코드 추가

## Files Changed

| 파일 | 변경 유형 |
|------|----------|
| `RomRom-Domain-Auth/.../dto/KakaoFirebaseTokenRequest.java` | Modified |
| `RomRom-Domain-Auth/.../service/KakaoAuthService.java` | Modified |
| `RomRom-Web/.../controller/api/AuthControllerDocs.java` | Modified |

## Testing

- Gradle 빌드 (`BUILD SUCCESSFUL`) 확인
- 프로젝트 방침에 따라 단위/통합 테스트 코드 미작성

## Related Issues

Relates to #777
Closes #911

## Artifacts

- `.report/20260605_#777_카카오_Firebase_Custom_Token_발급_API_추가.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 카카오 로그인 시 이메일 정보를 추가로 제공할 수 있도록 개선
  * 기존 카카오 회원에 대한 사전 매칭 기능 추가로 로그인 프로세스 개선

* **Documentation**
  * Firebase Custom Token 발급 API 문서 업데이트 및 에러 코드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->