### PR TITLE
20260605_#777_카카오_Firebase_Custom_Token_발급_API_추가_및_소셜_로그인_연동_수정 : fix : preMatchExistingMember firebaseUid 조건을 null 체크에서 uid 비교로 수정 https://github.com/TEAM-ROMROM/RomRom-BE/issues/777

### DIFF
--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/KakaoAuthService.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/KakaoAuthService.java
@@ -88,8 +88,8 @@ public class KakaoAuthService {
       throw new EmailAlreadyRegisteredException(member.getSocialPlatform());
     }
 
-    // oidc.kakao → custom token 전환 시 firebaseUid 최초 세팅
-    if (member.getFirebaseUid() == null) {
+    // oidc.kakao → custom token 전환 시 firebaseUid 세팅 (기존 oidc.kakao uid와 다른 경우 포함)
+    if (!kakaoFirebaseUid.equals(member.getFirebaseUid())) {
       member.setFirebaseUid(kakaoFirebaseUid);
       memberRepository.save(member);
       log.debug("기존 카카오 회원 firebaseUid 세팅 완료: email={}, firebaseUid={}", requestEmail, kakaoFirebaseUid);


### PR DESCRIPTION
## Summary

`KakaoAuthService.preMatchExistingMember()`에서 기존 oidc.kakao 방식으로 로그인한 회원이 카카오 웹 로그인(Custom Token) 시 기존 회원으로 인식되지 않는 버그를 수정한다. `null` 체크 조건을 실제 uid 비교로 변경하여 `"oidc.kakao:12345678"` 형식의 firebaseUid가 이미 세팅된 회원도 `"kakao:12345678"` uid로 업데이트되도록 한다.

## Changes

- **bug fix** — `preMatchExistingMember()` firebaseUid 조건을 `== null` → `!kakaoFirebaseUid.equals(member.getFirebaseUid())` 로 변경

## Files Changed

| 파일 | 변경 유형 |
|---|---|
| `RomRom-Domain-Auth/src/main/java/com/romrom/auth/service/KakaoAuthService.java` | Modified |

## Testing

- 개발 환경에서 기존 oidc.kakao 회원으로 카카오 웹 로그인 시 기존 회원 데이터(isFirstItemPosted 등)가 정상 반환되는지 확인 필요
- DB에 잘못 생성된 `kakao:{id}` 신규 회원 레코드가 있는 경우 수동 삭제 필요 (개발 환경 한정)

## Related Issues

Closes #777

## Artifacts

- `.report/20260605_#777_카카오_Firebase_Custom_Token_발급_API_추가.md`
- `.report/20260605_#911_카카오_Custom_Token_기존_회원_email_pre-matching_추가.md`
- `docs/superpowers/plans/2026-06-05-kakao-firebase-custom-token.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카카오 기존 회원의 사용자 식별 업데이트 로직을 개선했습니다. 인증 방식 전환 과정에서 발생하는 식별자 불일치 문제가 해결되어 더욱 안정적이고 일관성 있는 인증 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->