### PR TITLE
actuator 메트릭 관리자 인증 경로 보강

### DIFF
--- a/RomRom-Domain-Auth/src/main/java/com/romrom/auth/filter/AdminJwtAuthenticationFilter.java
+++ b/RomRom-Domain-Auth/src/main/java/com/romrom/auth/filter/AdminJwtAuthenticationFilter.java
@@ -38,9 +38,10 @@ public class AdminJwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
         
-        // 관리자 경로 또는 Swagger 경로가 아니면 다음 필터로
+        // 관리자 경로, Swagger 경로, Actuator 경로가 아니면 다음 필터로
         boolean isSwaggerPath = pathMatcher.match("/docs/**", uri) || pathMatcher.match("/v3/api-docs/**", uri);
-        if (!uri.startsWith("/admin") && !uri.startsWith("/api/admin") && !isSwaggerPath) {
+        boolean isActuatorPath = uri.startsWith("/actuator/");
+        if (!uri.startsWith("/admin") && !uri.startsWith("/api/admin") && !isSwaggerPath && !isActuatorPath) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -54,10 +55,10 @@ public class AdminJwtAuthenticationFilter extends OncePerRequestFilter {
 
         log.debug("관리자 페이지 JWT 인증 필터 실행: {}", uri);
 
-        // API 요청인지 페이지 요청인지 구분
-        boolean isApiRequest = uri.startsWith("/api/admin") || 
+        // API 요청인지 페이지 요청인지 구분 (Actuator는 HTML 페이지가 없으므로 항상 API 취급)
+        boolean isApiRequest = uri.startsWith("/api/admin") || isActuatorPath ||
                               "XMLHttpRequest".equals(request.getHeader("X-Requested-With")) ||
-                              (request.getHeader("Accept") != null && 
+                              (request.getHeader("Accept") != null &&
                                request.getHeader("Accept").contains("application/json"));
 
         try {

--- a/RomRom-Web/src/test/java/com/romrom/web/config/ConfigBindingTest.java
+++ b/RomRom-Web/src/test/java/com/romrom/web/config/ConfigBindingTest.java
@@ -4,19 +4,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.romrom.web.RomBackApplication;
 import com.zaxxer.hikari.HikariDataSource;
+import java.util.List;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 /**
  * 설정값이 실제로 Spring 컨텍스트에 바인딩되는지 검증하는 통합 테스트.
@@ -24,11 +35,16 @@ import org.springframework.test.context.ActiveProfiles;
  * 로컬 PostgreSQL/MongoDB/Redis가 필요하다.
  * open-in-view 단언은 미보호 LAZY 연관관계 전수 감사 이후 false로 전환할 때
  * 전환 완료를 증명하는 장치다.
+ *
+ * @SpringBootTest는 기본적으로 management.defaults.metrics.export.enabled=false를 주입해
+ * 메트릭 export(프로메테우스 포함)를 꺼버린다. prometheus 실제 스크레이핑 응답을 검증하려면
+ * @AutoConfigureObservability로 다시 켜야 한다 (tracing은 이 테스트와 무관해 꺼둔다).
  */
 @SpringBootTest(
     classes = RomBackApplication.class,
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev")
+@AutoConfigureObservability(tracing = false)
 @Slf4j
 class ConfigBindingTest {
 
@@ -40,6 +56,12 @@ class ConfigBindingTest {
 
   @Autowired
   TestRestTemplate testRestTemplate;
+
+  @Value("${admin.username}")
+  String adminUsername;
+
+  @Value("${admin.password}")
+  String adminPassword;
 
   @Test
   @DisplayName("open-in-view가 Spring에 실제로 바인딩된다 (과거 키 위치 오류로 무시된 이력)")
@@ -84,5 +106,55 @@ class ConfigBindingTest {
         prometheusResponse.getStatusCode() == HttpStatus.UNAUTHORIZED
             || prometheusResponse.getStatusCode() == HttpStatus.FORBIDDEN,
         "인증 없이 prometheus에 접근됐다. 실제 응답: " + prometheusResponse.getStatusCode());
+  }
+
+  @Test
+  @DisplayName("관리자 토큰이면 prometheus 메트릭에 접근된다 (actuator 경로 인증 주체 미설정 회귀 방지)")
+  void actuator_prometheus는_관리자_토큰으로_접근된다() {
+    String adminAccessToken = loginAsAdminAndGetAccessToken();
+
+    HttpHeaders authorizedHeaders = new HttpHeaders();
+    authorizedHeaders.setBearerAuth(adminAccessToken);
+    // Prometheus 스크레이핑 엔드포인트는 text/plain만 생성하므로 실제 스크레이퍼처럼 명시한다
+    // (TestRestTemplate 기본 Accept는 application/json만 협상해 콘텐츠 협상 실패로 이어진다)
+    authorizedHeaders.setAccept(List.of(MediaType.TEXT_PLAIN, MediaType.ALL));
+    ResponseEntity<String> prometheusResponse = testRestTemplate.exchange(
+        "/actuator/prometheus",
+        HttpMethod.GET,
+        new HttpEntity<>(authorizedHeaders),
+        String.class);
+
+    assertEquals(HttpStatus.OK, prometheusResponse.getStatusCode());
+    String prometheusBody = prometheusResponse.getBody();
+    assertTrue(prometheusBody != null && prometheusBody.contains("hikaricp_"),
+        "hikaricp_ 지표가 응답에 없다");
+    assertTrue(prometheusBody.contains("jvm_"),
+        "jvm_ 지표가 응답에 없다");
+  }
+
+  /**
+   * 관리자 계정으로 로그인해 accessToken을 발급받는다 (RomRomInitiation이 기동 시 계정을 자동 생성함)
+   */
+  private String loginAsAdminAndGetAccessToken() {
+    MultiValueMap<String, String> loginForm = new LinkedMultiValueMap<>();
+    loginForm.add("username", adminUsername);
+    loginForm.add("password", adminPassword);
+
+    HttpHeaders multipartHeaders = new HttpHeaders();
+    multipartHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+    ResponseEntity<String> loginResponse = testRestTemplate.postForEntity(
+        "/api/admin/login",
+        new HttpEntity<>(loginForm, multipartHeaders),
+        String.class);
+
+    assertEquals(HttpStatus.OK, loginResponse.getStatusCode(), "관리자 로그인 실패: " + loginResponse.getBody());
+
+    try {
+      JsonNode loginResponseJson = new ObjectMapper().readTree(loginResponse.getBody());
+      return loginResponseJson.get("accessToken").asText();
+    } catch (Exception e) {
+      throw new IllegalStateException("관리자 로그인 응답 파싱 실패: " + loginResponse.getBody(), e);
+    }
   }
 }


### PR DESCRIPTION
- https://github.com/TEAM-ROMROM/RomRom-BE/issues/806

## 문제

PR #807 배포 후 운영에서 실측한 결과, `/actuator/prometheus`와 `/actuator/metrics`가 **관리자 토큰으로도 403**이 나서 아무도 접근할 수 없는 상태였습니다.

```
관리자 JWT(payload에 "role":"ROLE_ADMIN" 확인) → /actuator/prometheus  → 403
같은 토큰                                    → /api/admin/logs/files  → 500 (핸들러 도달 = 인가는 통과)
미인증                                       → /actuator/health       → 200 (정상)
```

### 원인

두 인증 필터 모두 `/actuator/*`를 처리하지 않습니다.

- `TokenAuthenticationFilter:59` — `uri.startsWith("/api/")`인 경우에만 Bearer 토큰을 읽음
- `AdminJwtAuthenticationFilter` — `/admin`, `/api/admin`, Swagger 경로만 처리

그 결과 `/actuator/*` 요청은 **인증 주체가 설정되지 않은 채** `hasRole("ADMIN")` 검사에 도달하고, 익명 사용자로 판정돼 403이 됩니다.

PR #807이 메트릭 엔드포인트를 `ADMIN_PATHS`로 옮기면서 드러난 문제입니다. 이 상태로는 PR #807의 목적인 "개선 효과를 메트릭으로 측정"이 불가능합니다.

## 수정

`AdminJwtAuthenticationFilter`가 `/actuator/` 경로도 처리하도록 확장했습니다. 이 필터는 이미 Swagger(`/docs/**`, `/v3/api-docs/**`)라는 비-`/api` 경로를 같은 방식으로 다루고 있어, 그 패턴을 그대로 따랐습니다.

`/actuator/health`는 필터의 화이트리스트 체크가 프리픽스 체크 뒤에 있어 **여전히 미인증 200**입니다. Dockerfile HEALTHCHECK와 Traefik 블루/그린 전환에 영향이 없습니다.

## 검증

`ConfigBindingTest`(실기동 통합 테스트, `RANDOM_PORT`) 6개 통과:

- 관리자 로그인 후 `/actuator/prometheus` → **200이고 본문에 `hikaricp_`, `jvm_` 지표 포함**
- 미인증 `/actuator/prometheus` → 접근 거부
- 미인증 `/actuator/health` → 200

관리자 자격증명은 `admin.yml`에서 `@Value`로 주입받아 씁니다. 테스트 코드에 하드코딩하지 않았습니다.

테스트 컨텍스트에 `@AutoConfigureObservability(tracing = false)`를 추가했습니다. `@SpringBootTest`가 기본으로 메트릭 export를 끄기 때문이며, 이를 되돌리는 Spring Boot 공식 수단입니다. 프로덕션 설정은 변경하지 않았습니다.

## 보안 리뷰 결과

- `/actuator/health` 미인증 200 유지 — 코드 추적 + 통합 테스트 양쪽 확인
- 필터의 `filterChain.doFilter()` 탈출 경로 4개 전수 추적 — 인증 우회 없음
- 일반 회원 토큰도 차단됨 (`TokenAuthenticationFilter`가 비-`/api/` 경로에 인증 주체를 세우지 않으므로 `ROLE_ADMIN` 검사에서 401)
- 뮤테이션 검증: 이 수정을 되돌리면 신규 테스트가 운영에서 관측된 증상(403)과 동일하게 실패

## 남은 후속 작업

1. **일반 회원 토큰의 메트릭 접근 차단 회귀 테스트** — 현재 동작은 정상이나, `ROLE_ADMIN` 검사가 나중에 제거되면 잡아낼 테스트가 없습니다.
2. **실제 Prometheus 스크레이퍼 운용 설계** — 지금은 만료되는 관리자 JWT를 요구해 스크레이퍼가 붙을 수 없습니다. 현재 수동 계측에는 문제없지만, 스크레이퍼 도입 전에 정적 크리덴셜 경로나 네트워크 레벨 제한이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * `/actuator/` 엔드포인트에 관리자 인증을 적용했습니다.
  * 인증되지 않은 Actuator 요청은 일관된 JSON 오류 응답으로 처리됩니다.
  * 관리자 인증 후 Prometheus 메트릭에 접근할 수 있습니다.
  * HikariCP 및 JVM 관련 메트릭이 정상적으로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->