### PR TITLE
hibernate 메트릭 수집 활성화

### DIFF
--- a/RomRom-Web/build.gradle
+++ b/RomRom-Web/build.gradle
@@ -22,6 +22,9 @@ dependencies {
     // Spring Boot Starters - Common에서 api로 제공하므로 중복 제거
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    // HibernateMetricsAutoConfiguration이 org.hibernate.stat.HibernateMetrics 클래스 존재를 조건으로 건다.
+    // 이 아티팩트가 없으면 generate_statistics를 켜도 hibernate_* 메트릭이 수집되지 않는다.
+    implementation 'org.hibernate.orm:hibernate-micrometer'
 
     // Database
     implementation 'org.postgresql:postgresql'

--- a/RomRom-Web/src/test/java/com/romrom/web/config/ConfigBindingTest.java
+++ b/RomRom-Web/src/test/java/com/romrom/web/config/ConfigBindingTest.java
@@ -132,6 +132,29 @@ class ConfigBindingTest {
         "jvm_ 지표가 응답에 없다");
   }
 
+  @Test
+  @DisplayName("hibernate 지표가 수집된다 (generate_statistics + hibernate-micrometer 둘 다 필요)")
+  void hibernate_지표가_수집된다() {
+    String adminAccessToken = loginAsAdminAndGetAccessToken();
+
+    HttpHeaders authorizedHeaders = new HttpHeaders();
+    authorizedHeaders.setBearerAuth(adminAccessToken);
+    authorizedHeaders.setAccept(List.of(MediaType.TEXT_PLAIN, MediaType.ALL));
+    ResponseEntity<String> prometheusResponse = testRestTemplate.exchange(
+        "/actuator/prometheus",
+        HttpMethod.GET,
+        new HttpEntity<>(authorizedHeaders),
+        String.class);
+
+    assertEquals(HttpStatus.OK, prometheusResponse.getStatusCode());
+    String prometheusBody = prometheusResponse.getBody();
+    // HibernateMetricsAutoConfiguration은 org.hibernate.stat.HibernateMetrics 클래스 존재를 조건으로 걸고,
+    // HibernateMetrics는 Statistics.isStatisticsEnabled()로 한 번 더 가드한다.
+    // 둘 중 하나만 빠져도 지표가 조용히 사라지므로 실제 수집 여부를 단언한다.
+    assertTrue(prometheusBody != null && prometheusBody.contains("hibernate_"),
+        "hibernate_ 지표가 응답에 없다. hibernate-micrometer 의존성 또는 generate_statistics 설정을 확인하라");
+  }
+
   /**
    * 관리자 계정으로 로그인해 accessToken을 발급받는다 (RomRomInitiation이 기동 시 계정을 자동 생성함)
    */


### PR DESCRIPTION
- https://github.com/TEAM-ROMROM/RomRom-BE/issues/806

## 문제

PR #807에서 `hibernate.generate_statistics: true`를 추가했지만, 배포 후 운영에서 확인한 결과 **`hibernate_*` 메트릭이 하나도 수집되지 않고 있었습니다.**

```
관리자 인증 후 /actuator/prometheus → 200, 총 601개 지표
그중 hibernate_ 로 시작하는 지표: 0개
```

`hikaricp_`, `jvm_`, `http_server_requests_` 등 나머지 지표는 정상이었습니다.

## 원인

Spring Boot 3.4.1의 `HibernateMetricsAutoConfiguration` 조건을 바이트코드로 확인했습니다.

```
@ConditionalOnClass({
    jakarta.persistence.EntityManagerFactory,
    org.hibernate.SessionFactory,
    org.hibernate.stat.HibernateMetrics,   ← 이것
    io.micrometer.core.instrument.MeterRegistry
})
```

`org.hibernate.stat.HibernateMetrics`는 Micrometer의 클래스(`io.micrometer.core.instrument.binder.jpa.HibernateMetrics`)가 아니라 **Hibernate 쪽 `hibernate-micrometer` 아티팩트**의 클래스입니다. 이 아티팩트는 `hibernate-core`에 포함되지 않는 별도 의존성이라 클래스패스에 없었고, 그 결과 auto-configuration 전체가 조용히 건너뛰어졌습니다.

`generate_statistics: true`만 켜둔 상태였으므로 **통계 수집 비용은 지불하면서 지표는 얻지 못하는** 상황이었습니다.

## 수정

`RomRom-Web/build.gradle`에 `org.hibernate.orm:hibernate-micrometer` 추가. 버전은 Spring Boot BOM이 관리하며 `hibernate-core`와 동일한 `6.6.4.Final`로 해석됩니다.

## 검증

`ConfigBindingTest`에 실제 수집 여부를 단언하는 테스트를 추가했습니다. 실기동 통합 테스트라 관리자 인증 후 `/actuator/prometheus` 응답 본문을 직접 확인합니다.

**뮤테이션 검증 수행**: 의존성을 주석 처리하고 재실행하면 새 테스트만 정확히 실패합니다. 이 테스트가 실제로 회귀를 잡는다는 것을 확인했습니다.

```
의존성 있음 → ApplicationYamlStructureTest 12개 + ConfigBindingTest 7개 전부 통과
의존성 없음 → hibernate_지표가_수집된다 FAILED
```

## 배경

이 문제는 `generate_statistics` 설정만으로는 드러나지 않습니다. 설정은 정상 반영됐고(배포본 jar에서 확인), 라이브러리도 있었지만, auto-configuration의 조건 클래스 하나가 빠져 지표만 조용히 사라졌습니다. 배포 후 실제 메트릭 응답을 눈으로 확인하지 않았다면 발견하지 못했을 종류의 문제입니다.
